### PR TITLE
Add app demo care report path for PlantGuide #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [Screenshots](#screenshots)
 - [Quick start](#quick-start)
 - [CLI reference](#cli-reference)
+- [App care report](#app-care-report)
 - [Species catalog](#species-catalog)
 - [Diagrams](#diagrams)
 - [Repository layout](#repository-layout)
@@ -60,6 +61,7 @@ plantguide species list
 plantguide identify tags -t "variegated,trailing,indoor" -k 3
 plantguide care show -s monstera_deliciosa
 plantguide care water -s monstera_deliciosa --season summer
+plantguide app demo --sample data/samples/obs_monstera.json --out data/out/e2e-monstera-care-report.json
 ```
 
 ---
@@ -74,7 +76,27 @@ plantguide care water -s monstera_deliciosa --season summer
 | `plantguide identify sample -f …` | Identify from observation file |
 | `plantguide care show -s <id>` | Care card JSON |
 | `plantguide care water -s <id>` | Watering hint |
+| `plantguide app demo --sample … --out …` | App-ready ID + care report |
 | `plantguide train toy` | Toy calibration |
+
+---
+
+## App care report
+
+Generate one JSON report that an app demo can embed directly:
+
+```powershell
+plantguide app demo --sample data/samples/obs_monstera.json --out data/out/e2e-monstera-care-report.json
+```
+
+The report is built from license-safe bundled sample tags only. It includes
+`report_type`, `integration_version`, `query_tags`, `top_species_id`, ranked
+`matches`, the top species `care_card`, and `license_safe_evidence` with no
+external assets. Inline tags are supported too:
+
+```powershell
+plantguide app demo -t "tropical,fenestrated leaves,climbing,indoor" -k 2
+```
 
 ---
 

--- a/src/plantguide/cli.py
+++ b/src/plantguide/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import typer
@@ -10,6 +11,7 @@ from plantguide import __version__
 from plantguide.care.cards import care_card_for_species, watering_hint
 from plantguide.data.loader import list_species_files, load_species
 from plantguide.identify.pipeline import identify_from_sample, identify_from_tags
+from plantguide.integrations.sdk import care_report_from_sample, care_report_from_tags
 from plantguide.train.toy_train import train_toy
 
 app = typer.Typer(
@@ -19,10 +21,12 @@ app = typer.Typer(
 species_app = typer.Typer(help="Species catalog")
 identify_app = typer.Typer(help="Identify plants from traits/tags")
 care_app = typer.Typer(help="Care guidance")
+app_app = typer.Typer(help="App embedding demos")
 train_app = typer.Typer(help="Training / calibration")
 app.add_typer(species_app, name="species")
 app.add_typer(identify_app, name="identify")
 app.add_typer(care_app, name="care")
+app.add_typer(app_app, name="app")
 app.add_typer(train_app, name="train")
 console = Console()
 
@@ -103,6 +107,43 @@ def care_svg(
     except KeyError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
+
+
+@app_app.command("demo")
+def app_demo(
+    sample: Path | None = typer.Option(
+        None,
+        "--sample",
+        exists=True,
+        dir_okay=False,
+        help="Observation JSON fixture to turn into an app care report.",
+    ),
+    tags: str | None = typer.Option(
+        None,
+        "--tags",
+        "-t",
+        help="Comma-separated observation tags to turn into an app care report.",
+    ),
+    out: Path | None = typer.Option(None, "--out", "-o", help="Write report JSON here."),
+    top: int = typer.Option(3, "--top", "-k", min=1, max=20),
+) -> None:
+    """Generate the documented app care-report JSON from sample data or tags."""
+    if bool(sample) == bool(tags):
+        console.print("[red]Provide exactly one of --sample or --tags.[/red]")
+        raise typer.Exit(code=1)
+
+    report = (
+        care_report_from_sample(sample, top_k=top)
+        if sample is not None
+        else care_report_from_tags(tags or "", top_k=top)
+    )
+    if out is None:
+        console.print_json(data=report)
+        return
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    console.print(f"[green]Care report[/green] {out}")
 
 
 @identify_app.command("disease")

--- a/src/plantguide/integrations/sdk.py
+++ b/src/plantguide/integrations/sdk.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from plantguide.care.cards import care_card_for_species
-from plantguide.identify.pipeline import identify_from_tags
+from plantguide.identify.pipeline import identify_from_sample, identify_from_tags
 
 
 def assess_for_app(tags: str | list[str], *, top_k: int = 3) -> dict:
@@ -16,3 +18,50 @@ def care_for_app(species_id: str) -> dict:
     card = care_card_for_species(species_id)
     card["integration_version"] = "plantguide.sdk.v1"
     return card
+
+
+def care_report_from_sample(sample: Path, *, top_k: int = 3) -> dict:
+    """Build the app demo care-report contract from a bundled observation sample."""
+    result = identify_from_sample(sample, top_k=top_k)
+    return _care_report(
+        result,
+        evidence_source=str(sample),
+        evidence_source_type="sample_fixture",
+    )
+
+
+def care_report_from_tags(tags: str | list[str], *, top_k: int = 3) -> dict:
+    """Build the app demo care-report contract from inline app tags."""
+    result = identify_from_tags(tags, top_k=top_k, with_care=True)
+    return _care_report(
+        result,
+        evidence_source="inline_tags",
+        evidence_source_type="inline_tags",
+    )
+
+
+def _care_report(result: dict, *, evidence_source: str, evidence_source_type: str) -> dict:
+    matches = list(result.get("matches") or [])
+    top_match = matches[0] if matches else None
+    care_card = result.get("top_care")
+    top_species_id = top_match.get("species_id") if top_match else None
+
+    return {
+        "report_type": "plantguide.app.care_report.v1",
+        "integration_version": "plantguide.sdk.v1",
+        "ready_for_ui": bool(top_species_id and care_card),
+        "sample_id": result.get("sample_id"),
+        "source": result.get("source"),
+        "query_tags": result.get("query_tags") or [],
+        "expected_species": result.get("expected_species"),
+        "hit_top1": result.get("hit_top1"),
+        "top_species_id": top_species_id,
+        "top_match": top_match,
+        "matches": matches,
+        "care_card": care_card,
+        "license_safe_evidence": {
+            "source": evidence_source,
+            "source_type": evidence_source_type,
+            "external_assets": [],
+        },
+    }

--- a/tests/test_app_report.py
+++ b/tests/test_app_report.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from plantguide.cli import app
+from plantguide.integrations.sdk import care_report_from_sample, care_report_from_tags
+
+
+def test_care_report_from_sample_schema() -> None:
+    report = care_report_from_sample(Path("data/samples/obs_monstera.json"), top_k=2)
+
+    assert report["report_type"] == "plantguide.app.care_report.v1"
+    assert report["integration_version"] == "plantguide.sdk.v1"
+    assert report["sample_id"] == "obs_monstera"
+    assert report["top_species_id"] == "monstera_deliciosa"
+    assert report["top_match"]["species_id"] == "monstera_deliciosa"
+    assert len(report["matches"]) == 2
+    assert report["care_card"]["species_id"] == "monstera_deliciosa"
+    assert report["ready_for_ui"] is True
+    assert report["license_safe_evidence"] == {
+        "source": "data/samples/obs_monstera.json",
+        "source_type": "sample_fixture",
+        "external_assets": [],
+    }
+
+
+def test_care_report_from_tags_schema() -> None:
+    report = care_report_from_tags(
+        "tropical,fenestrated leaves,climbing,indoor,large leaves",
+        top_k=1,
+    )
+
+    assert report["sample_id"] is None
+    assert report["top_species_id"] == "monstera_deliciosa"
+    assert report["care_card"]["common_name"] == "Monstera"
+    assert report["license_safe_evidence"]["source_type"] == "inline_tags"
+
+
+def test_app_demo_cli_writes_report(tmp_path: Path) -> None:
+    out_path = tmp_path / "e2e-monstera-care-report.json"
+    result = CliRunner().invoke(
+        app,
+        [
+            "app",
+            "demo",
+            "--sample",
+            "data/samples/obs_monstera.json",
+            "--out",
+            str(out_path),
+            "-k",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(out_path.read_text(encoding="utf-8"))
+    assert report["top_species_id"] == "monstera_deliciosa"
+    assert report["care_card"]["species_id"] == "monstera_deliciosa"
+    assert "Care report" in result.output


### PR DESCRIPTION
## Summary

- Add `plantguide app demo` to generate an app-ready JSON care report from a bundled observation sample or inline tags.
- Add SDK care-report builders that combine the top plant match, matching care card, ranked matches, and license-safe evidence metadata.
- Document the app care report command and add tests for the report schema, top match, care card inclusion, inline tags, and CLI file output.

## Linked issue / bounty

- Fixes #17
- Bounty issue: https://github.com/mergeos-bounties/PlantGuide/issues/17

## Problem

PlantGuide already has identification and care-card primitives, but issue #17 asks for a single documented E2E path suitable for embedding in a plant app with evidence logs and a sample care report.

## Fix

This adds the focused CLI/API path without external services or new assets:

- `plantguide app demo --sample ... --out ...` for bundled observation fixtures.
- `plantguide app demo --tags ...` for inline app tags.
- SDK helpers that return the top species, ranked matches, matching care card, UI-readiness flag, and sample-only/license-safe evidence metadata.

## Validation

- `pip install -e ".[dev]"`
- `pytest -q` -> `14 passed`
- `ruff check src tests` -> `All checks passed!`
- `plantguide app demo --sample data/samples/obs_monstera.json --out data/out/liaison-e2e-monstera-care-report.json`
  - verified `report_type=plantguide.app.care_report.v1`, `ready_for_ui=true`, `sample_id=obs_monstera`, `top_species_id=monstera_deliciosa`, `care_card.species_id=monstera_deliciosa`, `match_count=3`, and `license_safe_evidence.external_assets=[]`
- `plantguide app demo -t "tropical,fenestrated leaves,climbing,indoor" -k 2` -> top species `monstera_deliciosa`
- Existing commands still work: `plantguide identify sample -f data/samples/obs_monstera.json -k 2` and `plantguide care show -s monstera_deliciosa`

## Risk and rollback

Risk is low: the change is additive, uses existing fixture/species data, and does not add external APIs, private assets, dependencies, or broad ML/mobile SDK changes. Rollback is a normal revert of this PR.

## Maintainer notes

Happy to adjust the report field names or nesting if you prefer a different app contract.