### PR TITLE
feat(collection): user plant collection manager with watering reminders (Fixes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,15 @@ plantguide identify tags -t "indoor,trailing" -k 3
 ## License
 
 MIT · MergeOS / ThanhTrucSolutions
+
+## Collection manager
+
+Track a personal plant collection and get watering reminders:
+
+```bash
+plantguide collection add -s "Monstera deliciosa" --nickname "Monstera" --every 7
+plantguide collection list
+plantguide collection due --days 7
+```
+
+Store: `data/collection/plants.json` (override with `PLANTGUIDE_COLLECTION_DIR`).

--- a/src/plantguide/cli.py
+++ b/src/plantguide/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -9,6 +11,7 @@ from rich.table import Table
 
 from plantguide import __version__
 from plantguide.care.cards import care_card_for_species, watering_hint
+from plantguide.collection import add_plant, due_soon, list_plants, water_plant
 from plantguide.data.loader import list_species_files, load_species
 from plantguide.identify.pipeline import identify_from_sample, identify_from_tags
 from plantguide.integrations.sdk import care_report_from_sample, care_report_from_tags
@@ -28,6 +31,8 @@ app.add_typer(identify_app, name="identify")
 app.add_typer(care_app, name="care")
 app.add_typer(app_app, name="app")
 app.add_typer(train_app, name="train")
+collection_app = typer.Typer(help="User plant collection")
+app.add_typer(collection_app, name="collection")
 console = Console()
 
 
@@ -172,6 +177,99 @@ def train_report() -> None:
         console.print("[yellow]No report yet. Run: plantguide train toy[/yellow]")
         raise typer.Exit(code=1)
     console.print(path.read_text(encoding="utf-8"))
+
+
+@collection_app.command("add")
+def collection_add(
+    species: str = typer.Option(..., "--species", "-s"),
+    water_every_days: int = typer.Option(14, "--every", "-e", min=1),
+    nickname: str | None = typer.Option(None, "--nickname", "-n"),
+    last_watered: str | None = None,
+    note: str | None = None,
+) -> None:
+    """Add a plant to your collection."""
+    try:
+        rec = add_plant(
+            species,
+            water_every_days,
+            nickname=nickname,
+            last_watered=last_watered,
+            note=note,
+        )
+        console.print(f"[green]Added[/green] {rec['id']} ({species})")
+        console.print(f"  Water every {rec['water_every_days']} days")
+        if rec.get("nickname"):
+            console.print(f"  Nickname: {rec['nickname']}")
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from e
+
+
+@collection_app.command("list")
+def collection_list() -> None:
+    """List all plants in your collection."""
+    plants = list_plants()
+    if not plants:
+        console.print("[yellow]No plants in collection. Run: plantguide collection add[/yellow]")
+        raise typer.Exit()
+    table = Table(title="Your Plants")
+    table.add_column("ID")
+    table.add_column("Species")
+    table.add_column("Nickname")
+    table.add_column("Added")
+    table.add_column("Last Watered")
+    table.add_column("Due")
+    for p in plants:
+        table.add_row(
+            p.get("id", ""),
+            p.get("species", ""),
+            p.get("nickname", "") or "-",
+            p.get("added_at", ""),
+            p.get("last_watered", ""),
+            _due_str(p),
+        )
+    console.print(table)
+
+
+@collection_app.command("due")
+def collection_due(
+    within_days: int = typer.Option(7, "--days", "-d", min=0, max=30),
+) -> None:
+    """Show plants due for watering within N days."""
+    plants = due_soon(within_days=within_days)
+    if not plants:
+        console.print("[green]All caught up — no plants due![/green]")
+        raise typer.Exit()
+    table = Table(title=f"Due within {within_days} days")
+    table.add_column("ID")
+    table.add_column("Species")
+    table.add_column("Days Left")
+    table.add_column("Due Date")
+    table.add_column("Nickname")
+    for p in plants:
+        table.add_row(
+            p["id"],
+            p["species"],
+            str(p["days_left"]),
+            p["due_date"],
+            p.get("nickname", "") or "-",
+        )
+    console.print(table)
+
+
+def _due_str(plant: dict[str, Any]) -> str:
+    from plantguide.collection.store import next_watering
+
+    due = next_watering(plant)
+    today = date.today()
+    days_left = (due - today).days
+    if days_left < 0:
+        return f"[red]{-days_left}d late[/red]"
+    if days_left == 0:
+        return "[green]today[/green]"
+    if days_left == 1:
+        return "[yellow]tomorrow[/yellow]"
+    return f"{days_left}d"
 
 
 if __name__ == "__main__":

--- a/src/plantguide/collection/__init__.py
+++ b/src/plantguide/collection/__init__.py
@@ -1,0 +1,10 @@
+"""User plant collection manager — local JSON store with watering reminders."""
+
+from plantguide.collection.store import (
+    add_plant,
+    due_soon,
+    list_plants,
+    water_plant,
+)
+
+__all__ = ["add_plant", "list_plants", "due_soon", "water_plant"]

--- a/src/plantguide/collection/store.py
+++ b/src/plantguide/collection/store.py
@@ -1,0 +1,154 @@
+"""Local JSON store for a user plant collection.
+
+Each plant record:
+    {
+        "id": "PlantGuide#<n>",  # unique, sequential
+        "species": "aloe_vera",
+        "nickname": "Desk Aloe",        # optional
+        "added_at": "2026-07-12",
+        "last_watered": "2026-07-12",
+        "water_every_days": 14,
+        "note": "..."                   # optional
+    }
+
+The collection lives under ``data/collection/plants.json`` (overridable via the
+``PLANTGUIDE_COLLECTION_DIR`` environment variable). No network, no ROS, no
+runtime deps beyond the standard library.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def _collection_dir() -> Path:
+    raw = os.getenv("PLANTGUIDE_COLLECTION_DIR")
+    if raw:
+        path = Path(raw)
+    else:
+        path = Path(__file__).resolve().parents[2] / "data" / "collection"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _store_path() -> Path:
+    return _collection_dir() / "plants.json"
+
+
+def _today() -> date:
+    return date.today()
+
+
+def _parse(d: str) -> date:
+    return datetime.strptime(d, "%Y-%m-%d").date()
+
+
+def _fmt(d: date) -> str:
+    return d.strftime("%Y-%m-%d")
+
+
+def _load() -> list[dict[str, Any]]:
+    p = _store_path()
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _save(records: list[dict[str, Any]]) -> None:
+    _store_path().write_text(
+        json.dumps(records, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def _next_id(records: list[dict[str, Any]]) -> str:
+    max_n = 0
+    for r in records:
+        m = re.match(r"PlantGuide#(\d+)", str(r.get("id", "")))
+        if m:
+            max_n = max(max_n, int(m.group(1)))
+    return f"PlantGuide#{max_n + 1}"
+
+
+def add_plant(
+    species: str,
+    water_every_days: int,
+    nickname: str | None = None,
+    last_watered: str | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Add a plant to the collection and return the created record."""
+    if water_every_days <= 0:
+        raise ValueError("water_every_days must be positive")
+    today = _today()
+    records = _load()
+    rec: dict[str, Any] = {
+        "id": _next_id(records),
+        "species": species,
+        "added_at": _fmt(today),
+        "last_watered": last_watered or _fmt(today),
+        "water_every_days": water_every_days,
+    }
+    if nickname:
+        rec["nickname"] = nickname
+    if note:
+        rec["note"] = note
+    records.append(rec)
+    _save(records)
+    return rec
+
+
+def list_plants() -> list[dict[str, Any]]:
+    """Return all plants in the collection (oldest first)."""
+    return _load()
+
+
+def water_plant(plant_id: str, on_date: str | None = None) -> dict[str, Any]:
+    """Mark a plant as watered; returns the updated record or raises KeyError."""
+    records = _load()
+    for r in records:
+        if r.get("id") == plant_id:
+            r["last_watered"] = on_date or _fmt(_today())
+            _save(records)
+            return r
+    raise KeyError(f"plant id not found: {plant_id}")
+
+
+def due_soon(
+    within_days: int = 3, as_of: str | None = None
+) -> list[dict[str, Any]]:
+    """Return plants whose next watering is due within ``within_days`` (inclusive)."""
+    if within_days < 0:
+        raise ValueError("within_days must be >= 0")
+    today = _parse(as_of) if as_of else _today()
+    out: list[dict[str, Any]] = []
+    for r in _load():
+        try:
+            last = _parse(r["last_watered"])
+            every = int(r["water_every_days"])
+        except (KeyError, ValueError):
+            continue
+        due = last + timedelta(days=every)
+        days_left = (due - today).days
+        if days_left <= within_days:
+            enriched = dict(r)
+            enriched["due_date"] = _fmt(due)
+            enriched["days_left"] = days_left
+            out.append(enriched)
+    out.sort(key=lambda x: x["days_left"])
+    return out
+
+
+def next_watering(plant: dict[str, Any], as_of: str | None = None) -> date:
+    """Compute the next due date for a plant record."""
+    last = _parse(plant["last_watered"])
+    every = int(plant["water_every_days"])
+    return last + timedelta(days=every)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from plantguide.collection import add_plant, due_soon, list_plants, water_plant
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path, monkeypatch):
+    """Point the collection store at a temp dir so tests don't touch real data."""
+    monkeypatch.setenv("PLANTGUIDE_COLLECTION_DIR", str(tmp_path))
+    # Reload store module so it picks up the env override for _collection_dir.
+    import plantguide.collection.store as store
+
+    importlib.reload(store)
+    yield
+    importlib.reload(store)
+
+
+def test_add_plant_basic():
+    rec = add_plant("aloe_vera", 14)
+    assert rec["id"] == "PlantGuide#1"
+    assert rec["species"] == "aloe_vera"
+    assert rec["water_every_days"] == 14
+    assert "last_watered" in rec
+
+
+def test_add_plant_sequential_ids():
+    a = add_plant("aloe_vera", 14)
+    b = add_plant("pothos_golden", 7)
+    assert a["id"] == "PlantGuide#1"
+    assert b["id"] == "PlantGuide#2"
+
+
+def test_add_plant_invalid_interval():
+    with pytest.raises(ValueError):
+        add_plant("aloe_vera", 0)
+
+
+def test_add_plant_with_nickname_and_note():
+    rec = add_plant("monstera_deliciosa", 10, nickname="Monsty", note="bright corner")
+    assert rec["nickname"] == "Monsty"
+    assert rec["note"] == "bright corner"
+
+
+def test_list_plants_persists():
+    add_plant("aloe_vera", 14)
+    add_plant("zz_plant", 21)
+    plants = list_plants()
+    assert len(plants) == 2
+    ids = {p["id"] for p in plants}
+    assert ids == {"PlantGuide#1", "PlantGuide#2"}
+
+
+def test_water_plant_updates_last_watered():
+    rec = add_plant("aloe_vera", 14, last_watered="2026-07-01")
+    updated = water_plant(rec["id"], on_date="2026-07-10")
+    assert updated["last_watered"] == "2026-07-10"
+
+
+def test_water_plant_unknown_id():
+    with pytest.raises(KeyError):
+        water_plant("PlantGuide#999")
+
+
+def test_due_soon_finds_overdue_and_upcoming():
+    add_plant("aloe_vera", 14, last_watered="2026-07-01")  # due 07-15
+    add_plant("zz_plant", 21, last_watered="2026-07-12")   # due 08-02
+    due = due_soon(within_days=3, as_of="2026-07-14")
+    assert len(due) == 1
+    assert due[0]["id"] == "PlantGuide#1"
+    assert due[0]["days_left"] == 1
+
+
+def test_due_soon_empty_when_none_due():
+    add_plant("zz_plant", 21, last_watered="2026-07-12")  # due far out
+    assert due_soon(within_days=3, as_of="2026-07-14") == []
+
+
+def test_due_soon_sorted():
+    add_plant("a", 7, last_watered="2026-07-01")   # due 07-08
+    add_plant("b", 7, last_watered="2026-07-02")   # due 07-09
+    due = due_soon(within_days=10, as_of="2026-07-07")
+    assert [d["id"] for d in due] == ["PlantGuide#1", "PlantGuide#2"]


### PR DESCRIPTION
## Summary

Implements the **multi-species collection manager** for PlantGuide (#16, 100 MRG).

Local JSON store for a user plant collection with last-watered dates and due reminders:

- `plantguide collection add` — register a plant (species, `--every` days, optional `--nickname`, `--note`, `--last-watered`)
- `plantguide collection list` — rich table of all plants with computed **due status** (today / tomorrow / Nd / overdue)
- `plantguide collection due` — plants due for watering within N days (default 7), sorted by days-left

### Design

- Store at `data/collection/plants.json` (override via `PLANTGUIDE_COLLECTION_DIR`).
- Sequential IDs (`PlantGuide#1`, …), overwrite-safe load/save, no network, no ROS, no new runtime deps.
- Overdue detection + graceful empty states.

### Tests

- 10 offline unit tests in `tests/test_collection.py` (add / list / due / water, edge cases, sorting) — all passing.
- Verified E2E: add → list → due renders correctly.

## Evidence (Terminal Demo)

```
$ plantguide collection add -s "Monstera deliciosa" --nickname "Monstera" --every 7 --note "Swiss cheese plant"
Added PlantGuide#1 (Monstera deliciosa)
  Water every 7 days
  Nickname: Monstera

$ plantguide collection add -s "Epipremnum aureum" --nickname "Pothos" --every 5 --note "Trailing vine"
Added PlantGuide#2 (Epipremnum aureum)
  Water every 5 days
  Nickname: Pothos

$ plantguide collection add -s "Dracaena trifasciata" --nickname "Snake Plant" --every 14
Added PlantGuide#3 (Dracaena trifasciata)
  Water every 14 days
  Nickname: Snake Plant

$ plantguide collection list
                                  Your Plants                                   
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━┓
┃ ID           ┃ Species       ┃ Nickname    ┃ Added      ┃ Last Watered ┃ Due ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━┩
│ PlantGuide#1 │ Monstera      │ Monstera    │ 2026-07-12 │ 2026-07-12   │ 7d  │
│              │ deliciosa     │             │            │              │     │
│ PlantGuide#2 │ Epipremnum    │ Pothos      │ 2026-07-12 │ 2026-07-12   │ 5d  │
│              │ aureum        │             │            │              │     │
│ PlantGuide#3 │ Dracaena      │ Snake Plant │ 2026-07-12 │ 2026-07-12   │ 14d │
│              │ trifasciata   │             │            │              │     │
└──────────────┴───────────────┴─────────────┴────────────┴──────────────┴─────┘

$ plantguide collection due --days 7
                            Due within 7 days                            
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID           ┃ Species            ┃ Days Left ┃ Due Date   ┃ Nickname ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩
│ PlantGuide#2 │ Epipremnum aureum  │ 5         │ 2026-07-17 │ Pothos   │
│ PlantGuide#1 │ Monstera deliciosa │ 7         │ 2026-07-19 │ Monstera │
└──────────────┴────────────────────┴───────────┴────────────┴──────────┘
```

## Claim

- [x] Starred https://github.com/mergeos-bounties/PlantGuide ✅
- [x] Starred https://github.com/mergeos-bounties/mergeos ✅
- [x] Claimed on issue #16 (comment 4952704534)
- [x] Claimed on MergeOS Claim Token #1 (comment 4952729216)

Fixes #16