### PR TITLE
feat: add 3 arid climate species cards

### DIFF
--- a/data/species/agave_americana.json
+++ b/data/species/agave_americana.json
@@ -1,0 +1,34 @@
+{
+  "id": "agave_americana",
+  "common_name": "Century Plant",
+  "scientific_name": "Agave americana",
+  "tags": [
+    "succulent",
+    "arid",
+    "drought tolerant",
+    "rosette",
+    "spiky",
+    "full sun",
+    "xeric"
+  ],
+  "care": {
+    "summary": "Large succulent rosette; extremely drought tolerant, needs full sun.",
+    "light": "Full sun to bright indirect",
+    "water": "Very infrequent; allow soil to dry completely between waterings",
+    "well_draining": true,
+    "soil": "Sandy, well-draining cactus mix",
+    "humidity": "Low",
+    "temperature_c": "10-35",
+    "fertilizer": "Rarely; balanced liquid once in spring",
+    "toxicity": "Sap can irritate skin; sharp spines",
+    "common_issues": [
+      "Root rot from overwatering",
+      "Mealybugs in leaf axils"
+    ],
+    "tips": [
+      "Plant in ground in warm climates",
+      "Wear gloves when handling",
+      "Pups can be separated"
+    ]
+  }
+}

--- a/data/species/ferocactus_wislenizeni.json
+++ b/data/species/ferocactus_wislenizeni.json
@@ -1,0 +1,34 @@
+{
+  "id": "ferocactus_wislenizeni",
+  "common_name": "Fishhook Barrel Cactus",
+  "scientific_name": "Ferocactus wislenizeni",
+  "tags": [
+    "cactus",
+    "arid",
+    "drought tolerant",
+    "barrel-shaped",
+    "spiny",
+    "full sun",
+    "xeric"
+  ],
+  "care": {
+    "summary": "Classic barrel cactus; thrives in hot, dry conditions with minimal care.",
+    "light": "Full sun (minimum 6 hours)",
+    "water": "Very infrequent; water only when completely dry",
+    "well_draining": true,
+    "soil": "Gritty cactus/succulent mix with perlite",
+    "humidity": "Low",
+    "temperature_c": "10-40",
+    "fertilizer": "None to minimal; cactus fertilizer once in spring",
+    "toxicity": "Sharp spines; handle with thick gloves",
+    "common_issues": [
+      "Root rot from overwatering",
+      "Etiolation in low light"
+    ],
+    "tips": [
+      "Perfect for desert-themed gardens",
+      "Can survive freezing if dry",
+      "Flowers in summer with proper care"
+    ]
+  }
+}

--- a/data/species/yucca_elephantipes.json
+++ b/data/species/yucca_elephantipes.json
@@ -1,0 +1,34 @@
+{
+  "id": "yucca_elephantipes",
+  "common_name": "Spineless Yucca",
+  "scientific_name": "Yucca elephantipes",
+  "tags": [
+    "succulent",
+    "arid",
+    "drought tolerant",
+    "tree-like",
+    "sword-shaped leaves",
+    "full sun",
+    "xeric"
+  ],
+  "care": {
+    "summary": "Tree-like succulent with sword-shaped leaves; very low maintenance.",
+    "light": "Full sun to partial shade",
+    "water": "Infrequent; drought tolerant once established",
+    "well_draining": true,
+    "soil": "Well-draining, sandy soil",
+    "humidity": "Low to average",
+    "temperature_c": "10-30",
+    "fertilizer": "Light; balanced fertilizer in spring",
+    "toxicity": "Mildly toxic to pets if ingested",
+    "common_issues": [
+      "Brown leaf tips from low humidity",
+      "Pest issues indoors (spider mites)"
+    ],
+    "tips": [
+      "Can tolerate some shade outdoors",
+      "Wipe leaves to prevent dust buildup",
+      "Prune dead leaves at base"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds 3 arid climate species cards as requested in #152.

### New species:
1. **Agave americana** (Century Plant) - Large succulent rosette, extremely drought tolerant
2. **Yucca elephantipes** (Spineless Yucca) - Tree-like succulent, very low maintenance
3. **Ferocactus wislenizeni** (Fishhook Barrel Cactus) - Classic barrel cactus, thrives in hot dry conditions

### Acceptance criteria:
- [x] Species cards follow existing JSON format
- [x] Includes care instructions, toxicity, common issues
- [x] Tags include "arid" and "drought tolerant"

Closes #152