### PR TITLE
feat: add Neon Pothos species pack (pothos_neon)

### DIFF
--- a/data/samples/obs_pothos_neon.json
+++ b/data/samples/obs_pothos_neon.json
@@ -1,0 +1,11 @@
+{
+  "id": "obs_pothos_neon",
+  "tags": [
+    "chartreuse leaves",
+    "trailing",
+    "easy",
+    "indoor",
+    "vining"
+  ],
+  "expected_species": "pothos_neon"
+}

--- a/data/species/pothos_neon.json
+++ b/data/species/pothos_neon.json
@@ -1,0 +1,43 @@
+{
+  "id": "pothos_neon",
+  "common_name": "Neon Pothos",
+  "scientific_name": "Epipremnum aureum 'Neon'",
+  "tags": [
+    "chartreuse leaves",
+    "trailing",
+    "vining",
+    "easy care",
+    "indoor",
+    "low light tolerant",
+    "air purifying",
+    "hanging basket"
+  ],
+  "care": {
+    "summary": "Hardy trailing vine with neon-yellow chartreuse leaves. Extremely forgiving; thrives in low to bright indirect light with minimal care.",
+    "light": "Low to bright indirect light; avoids direct sun which can scorch the neon leaves",
+    "water": "Allow top inch of soil to dry between waterings; every 7-10 days typically",
+    "well_draining": true,
+    "soil": "Standard potting mix with perlite for drainage",
+    "humidity": "Average household humidity (40-60%) is sufficient",
+    "temperature_c": "15-30",
+    "fertilizer": "Balanced liquid fertilizer monthly during spring and summer; skip in winter",
+    "toxicity": "Toxic to cats, dogs, and humans if ingested — contains calcium oxalate crystals",
+    "common_issues": [
+      "Loss of variegation/neon color in very low light",
+      "Root rot from overwatering or poorly draining soil",
+      "Brown leaf tips from dry air or fluoride in tap water",
+      "Mealybugs or spider mites in dry conditions"
+    ],
+    "tips": [
+      "Trim leggy vines to encourage bushier growth",
+      "Propagate easily by placing cuttings in water",
+      "Wipe leaves monthly to keep them shiny and dust-free",
+      "Use a hanging basket or let it trail from a shelf",
+      "Avoid fluoride-heavy tap water; use filtered or rain water if tips brown"
+    ]
+  },
+  "toxicity": [
+    "toxic_to_pets",
+    "toxic_to_humans"
+  ]
+}


### PR DESCRIPTION
## Changes

Added Neon Pothos (`pothos_neon`) species pack to the PlantGuide catalog.

### Files
- `data/species/pothos_neon.json` — Species data with care instructions, identification tags, and toxicity info
- `data/samples/obs_pothos_neon.json` — Observation sample for identification testing

### Care summary
Hardy trailing vine with neon-yellow chartreuse leaves. Extremely forgiving; thrives in low to bright indirect light. Toxic to pets — contains calcium oxalate crystals.

Fixes #137