### PR TITLE
[ Species Pack ] feat: add Bird's Eye Chili

### DIFF
--- a/data/observations/chili_bird_eye.json
+++ b/data/observations/chili_bird_eye.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "chili_bird_eye",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy chili bird eye specimen"
+}

--- a/data/species/chili_bird_eye.json
+++ b/data/species/chili_bird_eye.json
@@ -1,0 +1,32 @@
+{
+  "id": "chili_bird_eye",
+  "common_name": "Bird's Eye Chili",
+  "scientific_name": "Capsicum annuum 'Bird's Eye'",
+  "tags": [
+    "edible",
+    "fruiting",
+    "outdoor",
+    "spicy",
+    "perennial"
+  ],
+  "care": {
+    "summary": "Small but extremely hot chili pepper; thrives in warm tropical conditions.",
+    "light": "Full sun to partial shade",
+    "water": "Moderate; allow topsoil to dry slightly between waterings",
+    "soil": "Well-drained, slightly acidic soil with organic matter",
+    "humidity": "Average to medium",
+    "temperature_c": "20-32",
+    "fertilizer": "Balanced fertilizer monthly during growing season",
+    "toxicity": "Fruit is edible but very hot; avoid contact with eyes",
+    "common_issues": [
+      "Root rot from overwatering",
+      "Whitefly infestation",
+      "Fruit drop from temperature stress"
+    ],
+    "tips": [
+      "Harvest when fruits turn red for maximum heat",
+      "Can be grown in containers",
+      "Drought-tolerant once established"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Bird's Eye Chili** (`chili_bird_eye`) to the PlantGuide catalog.

**Fixes #85**

### Files
- `data/species/chili_bird_eye.json` — species care card (light, water, soil, humidity, temp, fertilizer, toxicity, issues, tips)
- `data/observations/chili_bird_eye.json` — observation record

### Details
- **Scientific name:** Capsicum annuum 'Bird's Eye'
- **Tags:** edible, fruiting, outdoor, spicy, perennial
- **Temperature:** 20-32°C

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
