### PR TITLE
[ Species Pack ] feat: add Taro / Elephant Ear

### DIFF
--- a/data/observations/colocasia_esculenta.json
+++ b/data/observations/colocasia_esculenta.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "colocasia_esculenta",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy colocasia esculenta specimen"
+}

--- a/data/species/colocasia_esculenta.json
+++ b/data/species/colocasia_esculenta.json
@@ -1,0 +1,32 @@
+{
+  "id": "colocasia_esculenta",
+  "common_name": "Taro / Elephant Ear",
+  "scientific_name": "Colocasia esculenta",
+  "tags": [
+    "edible",
+    "tropical",
+    "outdoor",
+    "aquatic",
+    "dramatic"
+  ],
+  "care": {
+    "summary": "Bold tropical with large heart-shaped leaves; edible corms used in many cuisines.",
+    "light": "Partial shade to filtered sun",
+    "water": "High; thrives in boggy or aquatic conditions",
+    "soil": "Rich, moisture-retentive soil; can grow in water",
+    "humidity": "High",
+    "temperature_c": "20-35",
+    "fertilizer": "Balanced fertilizer every 3-4 weeks",
+    "toxicity": "Corms must be cooked before eating (raw is toxic)",
+    "common_issues": [
+      "Aphids on new leaves",
+      "Leaf scorch in direct sun",
+      "Fungal spots in still, humid air"
+    ],
+    "tips": [
+      "Great for pond edges or rain gardens",
+      "Die back in winter; store corms in cool dry place",
+      "Use as a dramatic focal point in shade gardens"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Taro / Elephant Ear** (`colocasia_esculenta`) to the PlantGuide catalog.

**Fixes #65**

### Files
- `data/species/colocasia_esculenta.json` — species care card (light, water, soil, humidity, temp, fertilizer, toxicity, issues, tips)
- `data/observations/colocasia_esculenta.json` — observation record

### Details
- **Scientific name:** Colocasia esculenta
- **Tags:** edible, tropical, outdoor, aquatic, dramatic
- **Temperature:** 20-35°C

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
