### PR TITLE
[ Species Pack ] feat: add Pandan

### DIFF
--- a/data/observations/pandan.json
+++ b/data/observations/pandan.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "pandan",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy pandan specimen"
+}

--- a/data/species/pandan.json
+++ b/data/species/pandan.json
@@ -1,0 +1,32 @@
+{
+  "id": "pandan",
+  "common_name": "Pandan",
+  "scientific_name": "Pandanus amaryllifolius",
+  "tags": [
+    "edible",
+    "aromatic",
+    "tropical",
+    "perennial",
+    "leaf"
+  ],
+  "care": {
+    "summary": "Fragrant tropical plant whose leaves are widely used in Southeast Asian cooking.",
+    "light": "Partial shade to indirect light",
+    "water": "Keep soil moist; tolerates standing water",
+    "soil": "Rich, loamy, moisture-retentive soil",
+    "humidity": "High; mist regularly indoors",
+    "temperature_c": "22-35",
+    "fertilizer": "Balanced liquid fertilizer every 4-6 weeks",
+    "toxicity": "Safe for culinary use",
+    "common_issues": [
+      "Brown leaf tips from low humidity",
+      "Slow growth in cool temperatures",
+      "Mealybugs indoors"
+    ],
+    "tips": [
+      "Leaves release aroma when crushed or knotted",
+      "Use in rice, desserts, and drinks",
+      "Propagate by suckers or aerial roots"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Pandan** (`pandan`) to the PlantGuide catalog.

**Fixes #82**

### Files
- `data/species/pandan.json` — species care card (light, water, soil, humidity, temp, fertilizer, toxicity, issues, tips)
- `data/observations/pandan.json` — observation record

### Details
- **Scientific name:** Pandanus amaryllifolius
- **Tags:** edible, aromatic, tropical, perennial, leaf
- **Temperature:** 22-35°C

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
