### PR TITLE
[ Species Pack ] feat: add Satin Pothos

### DIFF
--- a/data/observations/scindapsus_pictus.json
+++ b/data/observations/scindapsus_pictus.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "scindapsus_pictus",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy scindapsus pictus specimen"
+}

--- a/data/species/scindapsus_pictus.json
+++ b/data/species/scindapsus_pictus.json
@@ -1,0 +1,32 @@
+{
+  "id": "scindapsus_pictus",
+  "common_name": "Satin Pothos",
+  "scientific_name": "Scindapsus pictus",
+  "tags": [
+    "trailing",
+    "vining",
+    "indoor",
+    "tropical",
+    "variegated"
+  ],
+  "care": {
+    "summary": "Stunning trailing vine with velvety dark green leaves splashed with silver.",
+    "light": "Medium indirect; tolerates lower light",
+    "water": "Water when top 2-3 cm dry; slightly drought-tolerant",
+    "soil": "Well-draining aroid mix with perlite",
+    "humidity": "Medium to high",
+    "temperature_c": "18-27",
+    "fertilizer": "Liquid feed every 4-6 weeks in growing season",
+    "toxicity": "Toxic if ingested (pets and humans)",
+    "common_issues": [
+      "Loss of silver variegation in low light",
+      "Curling leaves from underwatering",
+      "Pest issues with thrips"
+    ],
+    "tips": [
+      "More light = more silver splashing",
+      "Train on a wall or trellis for display",
+      "Propagate in water from node cuttings"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Satin Pothos** (`scindapsus_pictus`) to the PlantGuide catalog.

**Fixes #68**

### Files
- `data/species/scindapsus_pictus.json` — species care card (light, water, soil, humidity, temp, fertilizer, toxicity, issues, tips)
- `data/observations/scindapsus_pictus.json` — observation record

### Details
- **Scientific name:** Scindapsus pictus
- **Tags:** trailing, vining, indoor, tropical, variegated
- **Temperature:** 18-27°C

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
