### PR TITLE
[ Species Pack ] feat: add Arrowhead Plant

### DIFF
--- a/data/observations/syngonium_podophyllum.json
+++ b/data/observations/syngonium_podophyllum.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "syngonium_podophyllum",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy syngonium podophyllum specimen"
+}

--- a/data/species/syngonium_podophyllum.json
+++ b/data/species/syngonium_podophyllum.json
@@ -1,0 +1,32 @@
+{
+  "id": "syngonium_podophyllum",
+  "common_name": "Arrowhead Plant",
+  "scientific_name": "Syngonium podophyllum",
+  "tags": [
+    "trailing",
+    "tropical",
+    "indoor",
+    "beginner-friendly",
+    "air-purifying"
+  ],
+  "care": {
+    "summary": "Versatile vining or bushy plant with arrow-shaped leaves in green, pink, or white tones.",
+    "light": "Medium indirect; avoid direct sun",
+    "water": "Keep slightly moist; water when top inch is dry",
+    "soil": "Peat-based mix with perlite for drainage",
+    "humidity": "Medium to high",
+    "temperature_c": "18-27",
+    "fertilizer": "Balanced feed every 4 weeks in spring/summer",
+    "toxicity": "Toxic if ingested (pets and humans)",
+    "common_issues": [
+      "Brown leaf edges from dry air",
+      "Leggy growth without pruning",
+      "Spider mites in winter"
+    ],
+    "tips": [
+      "Trim regularly to keep bushy",
+      "Can grow in water indefinitely",
+      "Color varieties need more light for vivid tones"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Arrowhead Plant** (`syngonium_podophyllum`) to the PlantGuide catalog.

**Fixes #67**

### Files
- `data/species/syngonium_podophyllum.json` — species care card (light, water, soil, humidity, temp, fertilizer, toxicity, issues, tips)
- `data/observations/syngonium_podophyllum.json` — observation record

### Details
- **Scientific name:** Syngonium podophyllum
- **Tags:** trailing, tropical, indoor, beginner-friendly, air-purifying
- **Temperature:** 18-27°C

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
