### PR TITLE
feat: filter species by care needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ plantguide identify image -i data/samples/photos/monstera_demo.jpg -k 3
 plantguide care show -s monstera_deliciosa
 plantguide care water -s monstera_deliciosa --season summer
 plantguide care svg -s monstera_deliciosa
+plantguide species filter --light bright --water dry
 ```
 
 Example output (abridged):

--- a/src/plantguide/care/filtering.py
+++ b/src/plantguide/care/filtering.py
@@ -1,0 +1,28 @@
+"""Offline catalog filters built from normalized care-card fields."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def filter_species_by_care(
+    species: Iterable[dict], *, light: str | None = None, water: str | None = None
+) -> list[dict]:
+    """Return species whose light and water guidance contains every requested term."""
+    light_query = (light or "").strip().lower()
+    water_query = (water or "").strip().lower()
+
+    if not light_query and not water_query:
+        raise ValueError("provide --light, --water, or both")
+
+    matches: list[dict] = []
+    for item in species:
+        care = item.get("care") or {}
+        light_text = str(care.get("light") or "").lower()
+        water_text = str(care.get("water") or "").lower()
+        if light_query and light_query not in light_text:
+            continue
+        if water_query and water_query not in water_text:
+            continue
+        matches.append(item)
+    return matches

--- a/src/plantguide/cli.py
+++ b/src/plantguide/cli.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from plantguide import __version__
 from plantguide.care.cards import care_card_for_species, watering_hint
+from plantguide.care.filtering import filter_species_by_care
 from plantguide.collection import add_plant, due_soon, list_plants
 from plantguide.data.loader import list_species_files, load_species
 from plantguide.identify.pipeline import (
@@ -120,6 +121,36 @@ def species_search(
             str(sp.get("id")),
             str(sp.get("common_name")),
             str(sp.get("scientific_name") or ""),
+        )
+    console.print(table)
+
+
+@species_app.command("filter")
+def species_filter(
+    light: str | None = typer.Option(None, "--light", help="Substring in light-care guidance"),
+    water: str | None = typer.Option(None, "--water", help="Substring in water-care guidance"),
+) -> None:
+    """Filter the offline species catalog by light and water care guidance."""
+    try:
+        matches = filter_species_by_care(
+            (load_species(path) for path in list_species_files()), light=light, water=water
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    table = Table(title=f"Care filter ({len(matches)})")
+    table.add_column("ID")
+    table.add_column("Common name")
+    table.add_column("Light")
+    table.add_column("Water")
+    for item in matches:
+        care = item.get("care") or {}
+        table.add_row(
+            str(item.get("id")),
+            str(item.get("common_name")),
+            str(care.get("light") or ""),
+            str(care.get("water") or ""),
         )
     console.print(table)
 

--- a/tests/test_care_filtering.py
+++ b/tests/test_care_filtering.py
@@ -1,0 +1,25 @@
+import pytest
+
+from plantguide.care.filtering import filter_species_by_care
+from plantguide.data.loader import load_species_catalog
+
+
+def test_filter_species_by_light_and_water_uses_intersection() -> None:
+    species = [
+        {"id": "sun", "care": {"light": "Full sun", "water": "Water weekly"}},
+        {"id": "shade", "care": {"light": "Low light", "water": "Water weekly"}},
+        {"id": "dry", "care": {"light": "Full sun", "water": "Let soil dry"}},
+    ]
+
+    matches = filter_species_by_care(species, light="sun", water="weekly")
+
+    assert [item["id"] for item in matches] == ["sun"]
+
+
+def test_filter_species_by_care_matches_catalog_and_requires_a_filter() -> None:
+    matches = filter_species_by_care(load_species_catalog(), light="bright")
+
+    assert matches
+    assert all("bright" in str(item["care"].get("light") or "").lower() for item in matches)
+    with pytest.raises(ValueError, match="provide --light"):
+        filter_species_by_care(load_species_catalog())


### PR DESCRIPTION
## Summary
- add an offline `plantguide species filter` command with `--light` and `--water` filters
- require at least one filter and apply both filters as an intersection
- show matching species with their care guidance
- add a README example and focused tests

Fixes #180

## Tests
- `python -m pytest tests\\test_care.py tests\\test_care_filtering.py` (5 passed)
- `PYTHONPATH=src python -m plantguide.cli species filter --light bright --water dry` (43 matching catalog entries)