### PR TITLE
key1989han [ Botany ] feat(species): add Rau Răm / Vietnamese Coriander (vietnamese_coriander)

### DIFF
--- a/data/observations/vietnamese_coriander.json
+++ b/data/observations/vietnamese_coriander.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "vietnamese_coriander",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy rau r\u0103m / vietnamese coriander specimen"
+}

--- a/data/species/vietnamese_coriander.json
+++ b/data/species/vietnamese_coriander.json
@@ -1,0 +1,30 @@
+{
+  "id": "vietnamese_coriander",
+  "common_name": "Rau R\u0103m / Vietnamese Coriander",
+  "scientific_name": "Persicaria odorata",
+  "tags": [
+    "edible",
+    "herb",
+    "aromatic",
+    "tropical",
+    "aquatic"
+  ],
+  "care": {
+    "summary": "Aromatic herb essential in Vietnamese cuisine; thrives in moist conditions.",
+    "light": "Partial shade to filtered sun",
+    "water": "Keep consistently moist",
+    "soil": "Moisture-retentive loam",
+    "humidity": "High",
+    "temperature_c": "22-35",
+    "fertilizer": "Balanced feed monthly during growing season",
+    "toxicity": "Non-toxic",
+    "common_issues": [
+      "Leggy growth in low light",
+      "Root rot in stagnant water"
+    ],
+    "tips": [
+      "Grows well in water",
+      "Cut back to encourage bushiness"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Rau Răm / Vietnamese Coriander** (`vietnamese_coriander`) to the PlantGuide catalog.

**Fixes #83**

### Files
- `data/species/vietnamese_coriander.json` — species care card
- `data/observations/vietnamese_coriander.json` — observation record

### Details
- **Scientific name:** Persicaria odorata
- **Tags:** edible, herb, aromatic, tropical, aquatic

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
*Wallet: HXbVCN58WZ5RqVW5fgDzwLst73YWRZfxaCfxFzEhP7dm (Solana Mainnet)*
