### PR TITLE
key1989han [ Botany ] feat(species): add Lemongrass (lemongrass)

### DIFF
--- a/data/observations/lemongrass.json
+++ b/data/observations/lemongrass.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "lemongrass",
+  "observer": "key1989han",
+  "location": "Indoor",
+  "date": "2026-07-16",
+  "notes": "Healthy lemongrass specimen"
+}

--- a/data/species/lemongrass.json
+++ b/data/species/lemongrass.json
@@ -1,0 +1,30 @@
+{
+  "id": "lemongrass",
+  "common_name": "Lemongrass",
+  "scientific_name": "Cymbopogon citratus",
+  "tags": [
+    "edible",
+    "herb",
+    "aromatic",
+    "tropical",
+    "ornamental"
+  ],
+  "care": {
+    "summary": "Citrus-scented grass; essential in Southeast Asian cooking and herbal teas.",
+    "light": "Full sun",
+    "water": "Moderate; drought-tolerant once established",
+    "soil": "Well-draining, loamy soil",
+    "humidity": "Medium",
+    "temperature_c": "20-38",
+    "fertilizer": "Balanced feed monthly during growing season",
+    "toxicity": "Non-toxic",
+    "common_issues": [
+      "Brown leaf tips in dry climate",
+      "Slow growth in cool temps"
+    ],
+    "tips": [
+      "Divide clumps annually",
+      "Harvest outer stalks first"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **Lemongrass** (`lemongrass`) to the PlantGuide catalog.

**Fixes #81**

### Files
- `data/species/lemongrass.json` — species care card
- `data/observations/lemongrass.json` — observation record

### Details
- **Scientific name:** Cymbopogon citratus
- **Tags:** edible, herb, aromatic, tropical, ornamental

---
*Claimed by @key1989han via [MergeOS Bounty](https://github.com/mergeos-bounties/PlantGuide)*
*Wallet: HXbVCN58WZ5RqVW5fgDzwLst73YWRZfxaCfxFzEhP7dm (Solana Mainnet)*
