### PR TITLE
Add pot, season, and climate watering schedules

### DIFF
--- a/docs/WATERING_SCHEDULE.md
+++ b/docs/WATERING_SCHEDULE.md
@@ -1,0 +1,24 @@
+# Watering schedule assumptions
+
+`plantguide care schedule` estimates dates to **check the soil**, not dates on which
+watering is always required. Check the species guidance before adding water.
+
+The offline heuristic starts from the species care-card wording and adjusts the
+interval using three assumptions:
+
+- Pots under 12 cm dry faster, while pots over 20 cm retain moisture longer.
+- Summer and arid conditions shorten the interval; winter and humid conditions
+  lengthen it.
+- Species described as moisture-loving start at a shorter interval, while
+  drought-tolerant or fully-dry species start at a longer interval.
+
+Intervals are rounded to whole days and limited to 2-30 days. The command returns
+three upcoming check dates. Local light, airflow, soil mix, drainage, and plant
+health can outweigh the heuristic, so inspect the soil and plant before watering.
+
+Example:
+
+```console
+plantguide care schedule --species monstera_deliciosa --pot-cm 18 \
+  --season summer --climate temperate --as-of 2026-07-17
+```

--- a/src/plantguide/care/cards.py
+++ b/src/plantguide/care/cards.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
+
 from plantguide.data.loader import get_species_by_id
 
 
@@ -40,4 +42,78 @@ def watering_hint(species_id: str, season: str = "summer") -> dict:
         "season": season_key,
         "water": base,
         "seasonal_note": extra,
+    }
+
+
+_SEASON_FACTORS = {
+    "spring": 1.0,
+    "summer": 0.8,
+    "autumn": 1.2,
+    "winter": 1.6,
+}
+_CLIMATE_FACTORS = {
+    "arid": 0.8,
+    "temperate": 1.0,
+    "humid": 1.25,
+}
+
+
+def watering_schedule(
+    species_id: str,
+    pot_size_cm: float,
+    season: str = "summer",
+    climate: str = "temperate",
+    as_of: date | None = None,
+) -> dict:
+    """Calculate three soil-check dates using an intentionally simple offline heuristic."""
+    if pot_size_cm <= 0:
+        raise ValueError("pot_size_cm must be greater than zero")
+
+    season_key = season.strip().lower()
+    climate_key = climate.strip().lower()
+    if season_key not in _SEASON_FACTORS:
+        raise ValueError(f"season must be one of: {', '.join(_SEASON_FACTORS)}")
+    if climate_key not in _CLIMATE_FACTORS:
+        raise ValueError(f"climate must be one of: {', '.join(_CLIMATE_FACTORS)}")
+
+    card = care_card_for_species(species_id)
+    water_guidance = str(card.get("water") or "")
+    guidance_lower = water_guidance.lower()
+    base_days = 7
+    if any(term in guidance_lower for term in ("very infrequent", "2–4 weeks", "2-4 weeks", "sparse")):
+        base_days = 18
+    elif any(term in guidance_lower for term in ("fully dry", "dry completely", "soak and dry")):
+        base_days = 14
+    elif any(term in guidance_lower for term in ("keep evenly moist", "keep moist", "lightly moist")):
+        base_days = 4
+
+    if pot_size_cm < 12:
+        pot_factor = 0.75
+    elif pot_size_cm <= 20:
+        pot_factor = 1.0
+    elif pot_size_cm <= 30:
+        pot_factor = 1.25
+    else:
+        pot_factor = 1.5
+
+    interval_days = round(
+        base_days * pot_factor * _SEASON_FACTORS[season_key] * _CLIMATE_FACTORS[climate_key]
+    )
+    interval_days = max(2, min(30, interval_days))
+    start = as_of or date.today()
+    next_checks = [
+        (start + timedelta(days=interval_days * step)).isoformat() for step in range(1, 4)
+    ]
+
+    return {
+        "species_id": card["species_id"],
+        "common_name": card["common_name"],
+        "pot_size_cm": pot_size_cm,
+        "season": season_key,
+        "climate": climate_key,
+        "water_guidance": water_guidance,
+        "interval_days": interval_days,
+        "as_of": start.isoformat(),
+        "next_check_dates": next_checks,
+        "action": "Check soil moisture first; water only when the species guidance says it is dry enough.",
     }

--- a/src/plantguide/cli.py
+++ b/src/plantguide/cli.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from plantguide import __version__
-from plantguide.care.cards import care_card_for_species, watering_hint
+from plantguide.care.cards import care_card_for_species, watering_hint, watering_schedule
 from plantguide.care.filtering import filter_species_by_care
 from plantguide.collection import add_plant, due_soon, list_plants
 from plantguide.data.loader import list_species_files, load_species
@@ -335,6 +335,30 @@ def care_water(
     try:
         console.print_json(data=watering_hint(species, season=season))
     except KeyError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+
+@care_app.command("schedule")
+def care_schedule(
+    species: str = typer.Option(..., "--species", "-s"),
+    pot_size_cm: float = typer.Option(..., "--pot-cm", min=5, max=100),
+    season: str = typer.Option("summer", "--season"),
+    climate: str = typer.Option("temperate", "--climate"),
+    as_of: str | None = typer.Option(None, "--as-of", help="Optional YYYY-MM-DD reference date"),
+) -> None:
+    """Estimate upcoming soil-check dates from pot size, season, and climate."""
+    try:
+        console.print_json(
+            data=watering_schedule(
+                species,
+                pot_size_cm,
+                season=season,
+                climate=climate,
+                as_of=date.fromisoformat(as_of) if as_of else None,
+            )
+        )
+    except (KeyError, ValueError) as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
 

--- a/tests/test_watering_schedule.py
+++ b/tests/test_watering_schedule.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+
+from typer.testing import CliRunner
+
+from plantguide.care.cards import watering_schedule
+from plantguide.cli import app
+
+
+def test_schedule_returns_reproducible_check_dates() -> None:
+    result = watering_schedule(
+        "monstera_deliciosa",
+        18,
+        season="summer",
+        climate="temperate",
+        as_of=date(2026, 7, 17),
+    )
+
+    assert result["interval_days"] == 6
+    assert result["next_check_dates"] == ["2026-07-23", "2026-07-29", "2026-08-04"]
+
+
+def test_larger_pot_and_humid_climate_extend_interval() -> None:
+    small_arid = watering_schedule(
+        "monstera_deliciosa", 10, climate="arid", as_of=date(2026, 7, 17)
+    )
+    large_humid = watering_schedule(
+        "monstera_deliciosa", 32, climate="humid", as_of=date(2026, 7, 17)
+    )
+
+    assert large_humid["interval_days"] > small_arid["interval_days"]
+
+
+def test_schedule_rejects_unknown_climate() -> None:
+    try:
+        watering_schedule("monstera_deliciosa", 18, climate="tropical")
+    except ValueError as exc:
+        assert "climate must be one of" in str(exc)
+    else:
+        raise AssertionError("unknown climate should be rejected")
+
+
+def test_schedule_cli_outputs_dates() -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "care",
+            "schedule",
+            "--species",
+            "monstera_deliciosa",
+            "--pot-cm",
+            "18",
+            "--season",
+            "summer",
+            "--climate",
+            "temperate",
+            "--as-of",
+            "2026-07-17",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert '"interval_days": 6' in result.stdout
+    assert "2026-07-23" in result.stdout


### PR DESCRIPTION
## Summary

- add a deterministic offline watering schedule based on species guidance, pot size, season, and climate
- expose three upcoming soil-check dates through plantguide care schedule
- document the heuristic assumptions and safety limits

## Testing

- pytest -q tests/test_watering_schedule.py (4 passed)
- pytest -q --ignore=tests/test_photo_identify.py (36 passed)
- uff check src tests

The four photo-identification tests require Pillow, which was unavailable in the reused local test environment.

Fixes #7