### PR TITLE
[ Species Pack ] feat: add platycerium bifurcatum

### DIFF
--- a/data/observations/platycerium_bifurcatum.json
+++ b/data/observations/platycerium_bifurcatum.json
@@ -1,0 +1,7 @@
+{
+  "species_id": "platycerium_bifurcatum",
+  "observer": "phoenix7956",
+  "location": "Reference herbarium data",
+  "date": "2026-07-18",
+  "notes": "Reference care data sourced from botanical databases; submitted as part of PlantGuide species pack bounty program"
+}

--- a/data/species/platycerium_bifurcatum.json
+++ b/data/species/platycerium_bifurcatum.json
@@ -1,0 +1,33 @@
+{
+  "id": "platycerium_bifurcatum",
+  "common_name": "Staghorn Fern",
+  "scientific_name": "Platycerium bifurcatum",
+  "tags": [
+    "fern",
+    "epiphyte",
+    "tropical",
+    "indoor",
+    "mounted",
+    "antler-shaped"
+  ],
+  "care": {
+    "summary": "Epiphytic fern with broad, forked, antler-shaped fronds that grow mounted on wood or in slatted baskets.",
+    "light": "Bright indirect light; tolerates some shade",
+    "water": "Soak root ball weekly; mist fronds in dry air",
+    "soil": "Sphagnum moss, bark, and orchid mix; not potted in normal soil",
+    "humidity": "High humidity preferred (60%+)",
+    "temperature_c": "15-27",
+    "fertilizer": "Dilute balanced fertilizer monthly during active growth",
+    "toxicity": "Non-toxic to humans and pets",
+    "common_issues": [
+      "Brown shield fronds are normal; do not remove them",
+      "Underwatering causes brown leaf edges",
+      "Low humidity leads to stunted growth"
+    ],
+    "tips": [
+      "Mount on wood or cork bark for natural growth habit",
+      "Soak the entire mount in water weekly rather than top watering",
+      "New fronds emerge from the center and emerge fuzzy white"
+    ]
+  }
+}


### PR DESCRIPTION
## Bounty: PlantGuide Species Pack

Adds **platycerium bifurcatum** (`platycerium_bifurcatum`) to the PlantGuide catalog.

**Closes #55**

### Files
- `data/species/platycerium_bifurcatum.json` — species care card
- `data/observations/platycerium_bifurcatum.json` — observation record

---
*Submitted by @phoenix7956 via [MergeOS Bounty](https://github.com/mergeos-bounties/mergeos)*