### PR TITLE
feat: add Oxalis triangularis (Purple Shamrock) species data

### DIFF
--- a/data/species/oxalis_triangularis.json
+++ b/data/species/oxalis_triangularis.json
@@ -1,0 +1,38 @@
+{
+  "id": "oxalis_triangularis",
+  "common_name": "Purple Shamrock",
+  "scientific_name": "Oxalis triangularis",
+  "tags": [
+    "bulb",
+    "indoor",
+    "outdoor",
+    "flowering",
+    "purple foliage",
+    "shade tolerant",
+    "low maintenance",
+    "air purifying"
+  ],
+  "care": {
+    "summary": "Stunning purple-leafed bulb plant that folds its leaves at night; rewarding and low-fuss with bright indirect light.",
+    "light": "Bright indirect light; tolerates partial shade — avoid harsh direct midday sun which fades purple colour",
+    "water": "Moderate; water when top 2-3 cm of soil is dry; reduce significantly during dormancy",
+    "soil": "Light, well-draining potting mix; slightly acidic (pH 6.0-7.0)",
+    "humidity": "Average household humidity; 40-60% preferred",
+    "temperature_c": "15-26",
+    "fertilizer": "Diluted balanced liquid fertilizer every 2-4 weeks during active growth; none during dormancy",
+    "toxicity": "Mildly toxic to cats, dogs, and horses if ingested in large quantities due to oxalic acid",
+    "common_issues": [
+      "Leggy growth and faded leaf colour in low light",
+      "Root rot from overwatering, especially during dormancy",
+      "Spider mites in dry indoor conditions",
+      "Leaves yellowing and dropping — may signal natural dormancy, not death"
+    ],
+    "tips": [
+      "Leaves fold up at night and in response to darkness — this is normal nyctinasty behaviour",
+      "Plant goes dormant 1-2 times per year; stop watering, let foliage die back, resume after 4-6 weeks",
+      "Easy to propagate by dividing the small corm clusters at repotting time",
+      "Thrives in terracotta pots that allow bulbs to breathe",
+      "Can be grown outdoors in partial shade in warm climates (USDA zones 8-11)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds care data for **Oxalis triangularis** (Purple Shamrock), a hugely popular houseplant with distinctive deep-purple, butterfly-shaped leaves — currently absent from the species database.

## What's added

- New file: `data/species/oxalis_triangularis.json`
- Follows the existing species JSON schema exactly
- Includes: light, water, soil, humidity, temperature, fertilizer, toxicity, common issues, and 5 care tips

## Species highlights

- **Type:** Bulb/corm, indoor + outdoor, shade tolerant
- **Unique trait:** Exhibits **nyctinasty** — leaves fold at night/in darkness (documented in tips)
- **Dormancy behaviour:** Goes dormant 1-2× per year; tip included to prevent owners mistaking it for plant death
- **Toxicity:** Mildly toxic to pets (oxalic acid) ⚠️ — noted clearly
- **Tags:** `bulb`, `indoor`, `outdoor`, `flowering`, `purple foliage`, `shade tolerant`, `low maintenance`, `air purifying`

## Checklist
- [x] Follows existing JSON schema
- [x] Scientific name verified (*Oxalis triangularis*)
- [x] Care data is accurate and consistent with other entries
- [x] File named in `snake_case` format
- [x] Toxicity clearly documented
