### PR TITLE
feat(species): add Maidenhair Fern (adiantum_raddianum) species pack

### DIFF
--- a/data/samples/obs_adiantum_raddianum.json
+++ b/data/samples/obs_adiantum_raddianum.json
@@ -1,0 +1,13 @@
+{
+  "id": "obs_adiantum_raddianum",
+  "tags": [
+    "fern",
+    "delicate fronds",
+    "black stems",
+    "humidity",
+    "shade",
+    "fan-shaped leaves",
+    "wiry stems"
+  ],
+  "expected_species": "adiantum_raddianum"
+}

--- a/data/species/adiantum_raddianum.json
+++ b/data/species/adiantum_raddianum.json
@@ -1,0 +1,41 @@
+{
+  "id": "adiantum_raddianum",
+  "common_name": "Maidenhair Fern",
+  "scientific_name": "Adiantum raddianum",
+  "tags": [
+    "fern",
+    "delicate fronds",
+    "black stems",
+    "humidity",
+    "shade",
+    "indoor",
+    "bathroom"
+  ],
+  "care": {
+    "summary": "Delicate fern with distinctive fan-shaped fronds on thin black wiry stems; elegant but fussy about humidity and watering consistency.",
+    "light": "Bright indirect to medium shade; no direct sun — leaves scorch easily",
+    "water": "Keep consistently moist with distilled or rainwater; never let dry out; avoid tap water chemicals",
+    "soil": "Rich, well-draining potting mix with peat moss or coco coir and perlite",
+    "humidity": "High (60-80% preferred); thrives in steamy bathrooms",
+    "temperature_c": "18-24",
+    "fertilizer": "Half-strength balanced liquid fertilizer every 2-4 weeks in spring/summer",
+    "toxicity": "Non-toxic to pets",
+    "common_issues": [
+      "Brown crispy leaf edges and frond drop from low humidity",
+      "Wilting fronds from letting soil dry out completely",
+      "Yellowing leaves from overwatering or poor drainage",
+      "Pale, washed-out fronds from too much direct light",
+      "Spider mites in dry conditions"
+    ],
+    "tips": [
+      "Use distilled or rainwater — sensitive to tap water minerals",
+      "Place in a bathroom or kitchen for natural humidity",
+      "Group with other humidity-loving plants on a pebble tray",
+      "Trim dead fronds at the base to encourage new growth",
+      "Never let the root ball fully dry out — recovery is difficult"
+    ]
+  },
+  "toxicity": [
+    "pet_safe"
+  ]
+}


### PR DESCRIPTION
Fixes #56

## What is delivered
- `data/species/adiantum_raddianum.json` — species card with 7 tags, care info (light, water, soil, humidity, temperature, fertilizer, toxicity), 5 common issues, and 5 care tips
- `data/samples/obs_adiantum_raddianum.json` — observation sample with matching tags for identification validation

## Verification
- `plantguide species list` — shows `adiantum_raddianum` as Maidenhair Fern
- `plantguide care show --species adiantum_raddianum` — returns full care card
- `plantguide identify tags --tags "delicate fronds,black stems,humidity,shade"` — top match is adiantum_raddianum (score 0.5714)
- `pytest` — 41/41 passed

## Photo evidence (CC BY 3.0, Forest & Kim Starr)
| Photo | URL |
|-------|-----|
| Habit (whole plant) | https://commons.wikimedia.org/wiki/File:Starr_030807-0142_Adiantum_raddianum.jpg |
| Habit close-up | https://commons.wikimedia.org/wiki/File:Starr_030807-0143_Adiantum_raddianum.jpg |
| Habit at Kahikinui | https://commons.wikimedia.org/wiki/File:Starr-180212-0290-Adiantum_raddianum-habit-Kahikinui-Maui_(26862017258).jpg |

All photos by Forest & Kim Starr, CC BY 3.0, sourced from Wikimedia Commons.

## Acceptance checklist
- [x] Species file + sample file merged
- [x] `plantguide care show -s adiantum_raddianum` works
- [x] Top match is reasonable for the sample tags
- [x] Photo evidence linked in PR (CC BY 3.0 licensed)
- [x] No private PII; toxicity disclaimer present (pet_safe)
- [x] Tests still pass; JSON valid