### PR TITLE
feat: add hoya_kerrii to species pack

### DIFF
--- a/data/samples/obs_hoya_kerrii.json
+++ b/data/samples/obs_hoya_kerrii.json
@@ -1,0 +1,8 @@
+{
+  "tags": [
+    "heart shaped leaf",
+    "succulent-like",
+    "gift plant"
+  ],
+  "expected_species": "hoya_kerrii"
+}

--- a/data/species/hoya_kerrii.json
+++ b/data/species/hoya_kerrii.json
@@ -1,0 +1,33 @@
+{
+  "id": "hoya_kerrii",
+  "common_name": "Sweetheart Hoya",
+  "scientific_name": "Hoya kerrii",
+  "tags": [
+    "heart shaped leaf",
+    "succulent-like",
+    "gift plant",
+    "climbing",
+    "epiphyte",
+    "houseplant"
+  ],
+  "care": {
+    "summary": "Famous for its thick, heart-shaped leaves. Often sold as a single rooted leaf, though it is naturally a vining plant.",
+    "light": "Bright, indirect light. Some direct morning sun is beneficial for growth.",
+    "water": "Allow soil to dry almost completely between waterings. Highly susceptible to overwatering due to succulent leaves.",
+    "soil": "Very well-draining, airy cactus or orchid mix.",
+    "humidity": "Average room humidity is fine, but thrives in 40-60%.",
+    "temperature_c": "15-28",
+    "fertilizer": "Diluted balanced liquid fertilizer every month during the growing season.",
+    "toxicity": "Non-toxic to cats and dogs.",
+    "common_issues": [
+      "Root rot from overwatering",
+      "Stunted growth (if it is a single leaf cutting without a node)",
+      "Mealybugs"
+    ],
+    "tips": [
+      "Single-leaf cuttings sold around Valentine's Day often lack a stem node and may never grow into a vine.",
+      "If it does vine, provide a trellis for support.",
+      "Requires patience, as it is a slow grower."
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #46

Added `hoya_kerrii` species and sample files to the database with all requested traits and care guidance.

### Photo Evidence (Creative Commons Licensed)
- [Whole plant view](https://upload.wikimedia.org/wikipedia/commons/e/ea/Hoya_kerrii_in_pot.jpg) (CC BY-SA 4.0)
- [Close-up leaf](https://upload.wikimedia.org/wikipedia/commons/8/87/Hoya_kerrii_leaf.jpg) (CC BY-SA 3.0)

I have ensured:
- Identification tags are present.
- All care fields are included.
- Sample traits match.