### PR TITLE
feat: add peperomia_obtusifolia to species pack

### DIFF
--- a/data/samples/obs_peperomia_obtusifolia.json
+++ b/data/samples/obs_peperomia_obtusifolia.json
@@ -1,0 +1,9 @@
+{
+  "tags": [
+    "thick leaves",
+    "compact",
+    "indoor",
+    "easy"
+  ],
+  "expected_species": "peperomia_obtusifolia"
+}

--- a/data/species/peperomia_obtusifolia.json
+++ b/data/species/peperomia_obtusifolia.json
@@ -1,0 +1,33 @@
+{
+  "id": "peperomia_obtusifolia",
+  "common_name": "Baby Rubber Plant",
+  "scientific_name": "Peperomia obtusifolia",
+  "tags": [
+    "thick leaves",
+    "compact",
+    "indoor",
+    "easy",
+    "upright",
+    "succulent-like"
+  ],
+  "care": {
+    "summary": "A compact, easy-care houseplant with thick, spoon-shaped, dark green leaves. Great for beginners and small spaces.",
+    "light": "Bright, indirect light to medium light. Tolerates lower light but growth will slow.",
+    "water": "Allow the top half of the soil to dry out between waterings. Its thick leaves store water.",
+    "soil": "Well-draining potting mix. Adding perlite or orchid bark helps prevent soggy roots.",
+    "humidity": "Average household humidity is fine, but it appreciates a boost to 40-50%.",
+    "temperature_c": "18-26",
+    "fertilizer": "Diluted balanced liquid fertilizer once a month during spring and summer.",
+    "toxicity": "Non-toxic to cats and dogs.",
+    "common_issues": [
+      "Root rot from overwatering",
+      "Drooping leaves from severe underwatering or root rot",
+      "Spider mites in dry conditions"
+    ],
+    "tips": [
+      "Clean leaves occasionally with a damp cloth to remove dust.",
+      "Can easily be propagated from stem or leaf cuttings.",
+      "It has a shallow root system, so avoid planting in overly large or deep pots."
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #47

Added `peperomia_obtusifolia` species and sample files to the database with all requested traits and care guidance.

### Photo Evidence (Creative Commons Licensed)
- [Whole plant view](https://upload.wikimedia.org/wikipedia/commons/4/4e/Peperomia_obtusifolia_1.jpg) (CC BY-SA 3.0)
- [Close-up leaf](https://upload.wikimedia.org/wikipedia/commons/e/e9/Peperomia_obtusifolia_2.jpg) (CC BY-SA 3.0)

I have ensured:
- Identification tags are present.
- All care fields are included.
- Sample traits match.