### PR TITLE
feat: add ficus_benjamina to species pack

### DIFF
--- a/data/samples/obs_ficus_benjamina.json
+++ b/data/samples/obs_ficus_benjamina.json
@@ -1,0 +1,9 @@
+{
+  "tags": [
+    "tree",
+    "small leaves",
+    "drooping branches",
+    "indoor"
+  ],
+  "expected_species": "ficus_benjamina"
+}

--- a/data/species/ficus_benjamina.json
+++ b/data/species/ficus_benjamina.json
@@ -1,0 +1,31 @@
+{
+  "id": "ficus_benjamina",
+  "common_name": "Weeping Fig",
+  "scientific_name": "Ficus benjamina",
+  "tags": [
+    "tree",
+    "small leaves",
+    "drooping branches",
+    "indoor",
+    "ficus",
+    "houseplant"
+  ],
+  "care": {
+    "summary": "A popular indoor tree with elegant, drooping branches and small glossy leaves. It is sensitive to changes in its environment.",
+    "light": "Bright, indirect light. Needs plenty of light to maintain its leaves.",
+    "water": "Water when the top 1-2 inches of soil feel dry. Needs consistent watering but do not let it sit in water.",
+    "soil": "Rich, fast-draining potting soil.",
+    "humidity": "Appreciates high humidity. Regular misting can help.",
+    "temperature_c": "18-24",
+    "fertilizer": "Liquid fertilizer every 2-4 weeks during the growing season.",
+    "toxicity": "Toxic to cats and dogs if ingested.",
+    "common_issues": [
+      "Leaf drop, often caused by sudden changes in light, temperature, or watering",
+      "Scale insects or spider mites in dry environments"
+    ],
+    "tips": [
+      "Avoid moving the plant once it is established, as changes often trigger leaf drop.",
+      "Keep away from cold drafts and heating vents."
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #58

Added `ficus_benjamina` species and sample files to the database with all requested traits and care guidance.

### Photo Evidence (Creative Commons Licensed)
- [Whole plant view](https://upload.wikimedia.org/wikipedia/commons/e/ec/Ficus_benjamina.jpg) (CC BY-SA)
- [Close-up leaf](https://upload.wikimedia.org/wikipedia/commons/0/07/Ficus_benjamina_leaves.jpg) (CC BY-SA)

I have ensured:
- Identification tags are present.
- All care fields are included.
- Sample traits match.