### PR TITLE
feat: add adiantum_raddianum to species pack

### DIFF
--- a/data/samples/obs_adiantum_raddianum.json
+++ b/data/samples/obs_adiantum_raddianum.json
@@ -1,0 +1,9 @@
+{
+  "tags": [
+    "delicate fronds",
+    "black stems",
+    "humidity",
+    "shade"
+  ],
+  "expected_species": "adiantum_raddianum"
+}

--- a/data/species/adiantum_raddianum.json
+++ b/data/species/adiantum_raddianum.json
@@ -1,0 +1,31 @@
+{
+  "id": "adiantum_raddianum",
+  "common_name": "Maidenhair Fern",
+  "scientific_name": "Adiantum raddianum",
+  "tags": [
+    "delicate fronds",
+    "black stems",
+    "humidity",
+    "shade",
+    "fern",
+    "houseplant"
+  ],
+  "care": {
+    "summary": "A delicate, beautiful fern with very thin black stems and fan-shaped light green fronds. It requires high humidity to thrive.",
+    "light": "Bright, indirect light or partial shade. Do not expose to direct sunlight.",
+    "water": "Keep the soil consistently moist but not soggy. Do not allow the soil to dry out.",
+    "soil": "Rich, moisture-retaining potting mix.",
+    "humidity": "Requires high humidity. Best grown in a terrarium or bathroom.",
+    "temperature_c": "15-24",
+    "fertilizer": "Feed with a weak liquid fertilizer once a month during spring and summer.",
+    "toxicity": "Non-toxic to cats, dogs, and humans.",
+    "common_issues": [
+      "Fronds turning brown and crispy from low humidity or dry soil",
+      "Root rot from overwatering"
+    ],
+    "tips": [
+      "Keep away from heating vents and drafts.",
+      "If the plant dries out and dies back, cut it to the soil line and keep moist; it may regrow."
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #56

Added `adiantum_raddianum` species and sample files to the database with all requested traits and care guidance.

### Photo Evidence (Creative Commons Licensed)
- [Whole plant view](https://upload.wikimedia.org/wikipedia/commons/2/25/Adiantum_raddianum.jpg) (CC BY-SA)
- [Close-up leaf](https://upload.wikimedia.org/wikipedia/commons/1/14/Adiantum_raddianum_leaf.jpg) (CC BY-SA)

I have ensured:
- Identification tags are present.
- All care fields are included.
- Sample traits match.