### PR TITLE
feat: add epipremnum_aureum to species pack

### DIFF
--- a/data/samples/obs_epipremnum_aureum.json
+++ b/data/samples/obs_epipremnum_aureum.json
@@ -1,0 +1,9 @@
+{
+  "tags": [
+    "heart leaves",
+    "trailing",
+    "variegated",
+    "indoor"
+  ],
+  "expected_species": "epipremnum_aureum"
+}

--- a/data/species/epipremnum_aureum.json
+++ b/data/species/epipremnum_aureum.json
@@ -1,0 +1,31 @@
+{
+  "id": "epipremnum_aureum",
+  "common_name": "Pothos / Devil's Ivy",
+  "scientific_name": "Epipremnum aureum",
+  "tags": [
+    "heart leaves",
+    "trailing",
+    "variegated",
+    "indoor",
+    "easy",
+    "houseplant"
+  ],
+  "care": {
+    "summary": "One of the easiest houseplants to grow. Features trailing vines with heart-shaped, often variegated leaves.",
+    "light": "Low to bright indirect light. Variegation is more pronounced in brighter light.",
+    "water": "Allow the top inch or two of soil to dry out between waterings. Drought tolerant.",
+    "soil": "Any well-draining potting mix.",
+    "humidity": "Does well in average room humidity but appreciates higher humidity.",
+    "temperature_c": "15-29",
+    "fertilizer": "Feed every 1-2 months with a basic houseplant fertilizer.",
+    "toxicity": "Toxic to dogs and cats; causes oral irritation if chewed.",
+    "common_issues": [
+      "Yellow leaves from overwatering",
+      "Loss of variegation if light is too low"
+    ],
+    "tips": [
+      "Easily propagated by placing stem cuttings in water.",
+      "Can be trained to climb a moss pole or allowed to trail from a hanging basket."
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #48

Added `epipremnum_aureum` species and sample files to the database with all requested traits and care guidance.

### Photo Evidence (Creative Commons Licensed)
- [Whole plant view](https://upload.wikimedia.org/wikipedia/commons/e/ec/Epipremnum_aureum.jpg) (CC BY-SA)
- [Close-up leaf](https://upload.wikimedia.org/wikipedia/commons/6/66/Epipremnum_aureum_leaf.jpg) (CC BY-SA)

I have ensured:
- Identification tags are present.
- All care fields are included.
- Sample traits match.