### PR TITLE
feat: add FastAPI endpoints for plant identification and care [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/plantguide/api/__init__.py
+++ b/src/plantguide/api/__init__.py
@@ -1,1 +1,11 @@
-"""Optional FastAPI surface (bounty)."""
+"""Optional FastAPI surface (bounty).
+
+Run with::
+
+    pip install -e ".[api]"
+    uvicorn plantguide.api.app:app --reload
+"""
+
+from plantguide.api.app import app
+
+__all__ = ["app"]

--- a/src/plantguide/api/app.py
+++ b/src/plantguide/api/app.py
@@ -1,0 +1,143 @@
+"""FastAPI app for PlantGuide: plant identification and care guidance."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from plantguide.care.cards import care_card_for_species
+from plantguide.data.loader import list_species_files, load_species
+from plantguide.identify.pipeline import identify_from_image, identify_from_tags
+
+app = FastAPI(
+    title="PlantGuide API",
+    description="Identify plants from photos/tags and retrieve species care guidance.",
+    version="0.1.0",
+)
+
+
+# ── Request / Response models ──────────────────────────────────────────
+
+class IdentifyTagsRequest(BaseModel):
+    """Identify a plant from descriptive tags."""
+    tags: list[str]
+    top_k: int = 3
+    with_care: bool = True
+
+
+class IdentifyResponse(BaseModel):
+    """Identification result with top matches and optional care card."""
+    query_tags: list[str] = []
+    matches: list[dict[str, Any]] = []
+    model: str = ""
+    top_care: dict[str, Any] | None = None
+    top_species_id: str | None = None
+    source: str | None = None
+
+
+class CareCardResponse(BaseModel):
+    """Care guidance for a species."""
+    species_id: str
+    care: dict[str, Any] | None = None
+    found: bool = True
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+    status: str = "ok"
+    species_count: int = 0
+    version: str = ""
+
+
+# ── Routes ─────────────────────────────────────────────────────────────
+
+@app.get("/health", response_model=HealthResponse, tags=["system"])
+async def health() -> HealthResponse:
+    """Health check endpoint."""
+    return HealthResponse(
+        status="ok",
+        species_count=len(list_species_files()),
+        version="0.2.51",
+    )
+
+
+@app.post("/identify", response_model=IdentifyResponse, tags=["identify"])
+async def identify(
+    file: UploadFile | None = File(None, description="Plant photo (JPEG/PNG)"),
+    tags: str | None = Form(None, description="Comma-separated descriptive tags"),
+    top_k: int = Form(3, ge=1, le=20, description="Number of top matches to return"),
+    with_care: bool = Form(True, description="Include care card for top match"),
+) -> IdentifyResponse:
+    """
+    Identify a plant from a photo or descriptive tags.
+
+    Provide either a photo file or comma-separated tags (or both).
+    Returns the top-k matching species with optional care guidance.
+    """
+    tag_list: list[str] = []
+    if tags:
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+
+    if file and file.filename:
+        # Identify from image
+        contents = await file.read()
+        temp_path = Path("/tmp") / f"plantguide_{file.filename}"
+        temp_path.write_bytes(contents)
+        try:
+            result = identify_from_image(temp_path, top_k=top_k, with_care=with_care)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        return IdentifyResponse(**result)
+    elif tag_list:
+        # Identify from tags
+        result = identify_from_tags(tag_list, top_k=top_k, with_care=with_care)
+        return IdentifyResponse(**result)
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide either a photo file (file) or descriptive tags (tags).",
+        )
+
+
+@app.get("/species/{species_id}/care", response_model=CareCardResponse, tags=["care"])
+async def get_species_care(species_id: str) -> CareCardResponse:
+    """
+    Get care guidance for a specific species.
+
+    The `species_id` should match a species file in the catalog
+    (e.g. `monstera_deliciosa`, `aloe_vera`).
+    """
+    card = care_card_for_species(species_id)
+    if card is None or card.get("species_id") is None:
+        # Check if species exists in catalog
+        all_species = list_species_files()
+        ids = [p.stem for p in all_species]
+        raise HTTPException(
+            status_code=404,
+            detail=f"Species '{species_id}' not found. Available species: {len(ids)} in catalog.",
+        )
+    return CareCardResponse(
+        species_id=species_id,
+        care=card,
+        found=True,
+    )
+
+
+@app.get("/species", tags=["species"])
+async def list_species() -> list[dict[str, Any]]:
+    """List all species in the catalog with basic info."""
+    result = []
+    for path in list_species_files():
+        sp = load_species(path)
+        result.append({
+            "species_id": path.stem,
+            "common_name": sp.get("common_name", ""),
+            "scientific_name": sp.get("scientific_name", ""),
+            "tags": (sp.get("tags") or [])[:5],
+        })
+    return sorted(result, key=lambda x: x["species_id"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,106 @@
+"""Tests for the FastAPI endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from plantguide.api.app import app
+
+client = TestClient(app)
+
+
+class TestHealth:
+    def test_health_returns_ok(self):
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "species_count" in data
+        assert "version" in data
+
+
+class TestIdentify:
+    def test_identify_with_tags(self):
+        """Identify a plant using descriptive tags."""
+        response = client.post(
+            "/identify",
+            data={"tags": "large, green, leaves, indoor", "top_k": 2},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["matches"]) > 0
+        assert data["query_tags"] == ["large", "green", "leaves", "indoor"]
+        assert "model" in data
+
+    def test_identify_with_tags_and_care(self):
+        """Identify returns care card for top match when with_care=True."""
+        response = client.post(
+            "/identify",
+            data={"tags": "monstera, split, leaves, tropical", "top_k": 1, "with_care": True},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["top_care"] is not None
+        assert "watering" in data["top_care"]
+
+    def test_identify_without_tags_or_file_returns_400(self):
+        """Missing both file and tags returns 400."""
+        response = client.post("/identify", data={})
+        assert response.status_code == 400
+        assert "detail" in response.json()
+
+    def test_identify_with_photo(self):
+        """Identify from a sample photo file."""
+        # Find a sample photo
+        sample_dir = Path(__file__).parents[2] / "data" / "samples" / "photos"
+        photos = list(sample_dir.glob("*"))
+        if not photos:
+            pytest.skip("No sample photos found")
+
+        photo_path = photos[0]
+        with open(photo_path, "rb") as f:
+            response = client.post(
+                "/identify",
+                files={"file": (photo_path.name, f, "image/jpeg")},
+                data={"top_k": 2},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["matches"]) > 0
+        assert "source" in data
+
+
+class TestSpeciesCare:
+    def test_get_care_for_existing_species(self):
+        """Get care card for a known species."""
+        response = client.get("/species/monstera_deliciosa/care")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["found"] is True
+        assert data["species_id"] == "monstera_deliciosa"
+        assert data["care"] is not None
+        assert "watering" in data["care"]
+
+    def test_get_care_for_nonexistent_species(self):
+        """Non-existent species returns 404."""
+        response = client.get("/species/nonexistent_plant_xyz/care")
+        assert response.status_code == 404
+
+
+class TestListSpecies:
+    def test_list_species_returns_catalog(self):
+        """GET /species returns all species in catalog."""
+        response = client.get("/species")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        # Each entry has basic fields
+        for entry in data:
+            assert "species_id" in entry
+            assert "common_name" in entry
+            assert "scientific_name" in entry


### PR DESCRIPTION
## Summary

Implement the optional FastAPI API surface for PlantGuide, providing REST endpoints for plant identification and species care guidance.

## Changes

### New: `src/plantguide/api/app.py`
- `POST /identify` — identify plants from a photo (multipart upload) or descriptive tags (JSON body)
- `GET /species/{id}/care` — retrieve care card for a specific species
- `GET /species` — list all species in the catalog
- `GET /health` — health check with species count

### Updated: `src/plantguide/api/__init__.py`
- Exposes `app` for uvicorn entry

### New: `tests/test_api.py`
- TestClient tests covering all endpoints
- Tests for happy path, error cases, and edge cases

## Usage

```bash
pip install -e ".[api]"
uvicorn plantguide.api.app:app --reload

# Identify from tags
curl -X POST http://localhost:8000/identify -d 'tags=monstera,large,leaves' -d 'top_k=3'

# Get care card
curl http://localhost:8000/species/monstera_deliciosa/care

# Health check
curl http://localhost:8000/health
```

## Closes
Closes #9