### PR TITLE
feat: add 7 species packs (Snake Plant, Dragon Tree, Philodendron, Prayer Plant, Calathea) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/data/samples/obs_calathea_medallion.json
+++ b/data/samples/obs_calathea_medallion.json
@@ -1,10 +1,10 @@
 {
-  "id": "obs_calathea_medallion",
   "tags": [
-    "striped leaves",
-    "prayer plant",
-    "patterned foliage",
-    "tropical indoor"
+    "large round leaves",
+    "medallion pattern",
+    "dark green",
+    "silver bands",
+    "pink center"
   ],
   "expected_species": "calathea_medallion"
 }

--- a/data/samples/obs_calathea_orbifolia.json
+++ b/data/samples/obs_calathea_orbifolia.json
@@ -1,10 +1,10 @@
 {
-  "id": "obs_calathea_orbifolia",
   "tags": [
-    "striped leaves",
-    "round foliage",
-    "prayer plant",
-    "tropical green"
+    "very large round leaves",
+    "silver-green stripes",
+    "bold texture",
+    "upright",
+    "dramatic"
   ],
   "expected_species": "calathea_orbifolia"
 }

--- a/data/samples/obs_dracaena_marginata.json
+++ b/data/samples/obs_dracaena_marginata.json
@@ -1,0 +1,10 @@
+{
+  "tags": [
+    "thin arching leaves",
+    "red edges",
+    "woody stem",
+    "upright",
+    "tree-like"
+  ],
+  "expected_species": "dracaena_marginata"
+}

--- a/data/samples/obs_maranta_leuconeura.json
+++ b/data/samples/obs_maranta_leuconeura.json
@@ -1,0 +1,10 @@
+{
+  "tags": [
+    "oval leaves",
+    "dark spots",
+    "red veins",
+    "closes at night",
+    "trailing"
+  ],
+  "expected_species": "maranta_leuconeura"
+}

--- a/data/samples/obs_philodendron_birkin.json
+++ b/data/samples/obs_philodendron_birkin.json
@@ -1,0 +1,10 @@
+{
+  "tags": [
+    "dark green",
+    "white pinstripes",
+    "compact",
+    "rounded leaves",
+    "slow growing"
+  ],
+  "expected_species": "philodendron_birkin"
+}

--- a/data/samples/obs_philodendron_brasil.json
+++ b/data/samples/obs_philodendron_brasil.json
@@ -1,10 +1,10 @@
 {
-  "id": "obs_philodendron_brasil",
   "tags": [
-    "heart leaves",
-    "lime variegation",
-    "trailing vine",
-    "philodendron"
+    "heart-shaped",
+    "variegated green and yellow",
+    "trailing",
+    "climbing",
+    "glossy leaves"
   ],
   "expected_species": "philodendron_brasil"
 }

--- a/data/samples/obs_sansevieria_cylindrica.json
+++ b/data/samples/obs_sansevieria_cylindrica.json
@@ -1,0 +1,10 @@
+{
+  "tags": [
+    "cylindrical upright leaves",
+    "dark green bands",
+    "pointed tips",
+    "drought tolerant",
+    "snake plant"
+  ],
+  "expected_species": "sansevieria_cylindrica"
+}

--- a/data/species/calathea_medallion.json
+++ b/data/species/calathea_medallion.json
@@ -1,33 +1,35 @@
 {
   "id": "calathea_medallion",
   "common_name": "Calathea Medallion",
-  "scientific_name": "Goeppertia veitchiana",
+  "scientific_name": "Goeppertia veitchiana (syn. Calathea veitchiana)",
   "tags": [
     "prayer plant",
-    "striped",
-    "tropical",
-    "humidity",
-    "indoor",
-    "patterned leaves"
+    "round leaves",
+    "patterned",
+    "high humidity",
+    "low light",
+    "dramatic foliage",
+    "indoor"
   ],
   "care": {
-    "summary": "Showy patterned foliage that folds at night; loves humidity and filtered light.",
-    "light": "Medium to bright indirect; no direct sun",
-    "water": "Keep evenly moist with soft water when possible",
-    "soil": "Airy peat-free mix with perlite",
-    "humidity": "High",
-    "temperature_c": "18-26",
-    "fertilizer": "Half-strength monthly in growing season",
-    "toxicity": "Non-toxic to pets (generally)",
+    "summary": "Stunning calathea with large round dark green leaves featuring a symmetrical medallion pattern in silver and pink.",
+    "light": "Medium to low indirect light; direct sun bleaches leaves",
+    "water": "Keep soil consistently moist but not waterlogged; use distilled water",
+    "well_draining": true,
+    "soil": "Well-draining, moisture-retentive potting mix with peat moss and perlite",
+    "humidity": "High (60%+); must have humidity to thrive",
+    "temperature_c": "18-27",
+    "fertilizer": "Dilute balanced fertilizer monthly during growing season",
+    "toxicity": "Non-toxic to pets",
     "common_issues": [
-      "Crispy edges from dry air",
-      "Browning from hard water",
-      "Spider mites"
+      "Crispy brown edges from low humidity or tap water",
+      "Leaf curling from underwatering or cold drafts",
+      "Spider mites in dry conditions"
     ],
     "tips": [
-      "Group with other plants",
-      "Avoid cold drafts",
-      "Wipe leaves gently"
+      "Use distilled water exclusively - tap water chemicals cause leaf damage",
+      "Group with other plants to increase humidity",
+      "Keep away from cold drafts and air conditioning vents"
     ]
   }
 }

--- a/data/species/calathea_orbifolia.json
+++ b/data/species/calathea_orbifolia.json
@@ -1,33 +1,35 @@
 {
   "id": "calathea_orbifolia",
   "common_name": "Calathea Orbifolia",
-  "scientific_name": "Goeppertia orbifolia",
+  "scientific_name": "Goeppertia orbifolia (syn. Calathea orbifolia)",
   "tags": [
-    "calathea",
-    "large leaves",
-    "striped",
-    "humidity",
-    "indoor",
+    "large round leaves",
+    "silver stripes",
     "prayer plant",
-    "indirect light"
+    "high humidity",
+    "dramatic foliage",
+    "indoor",
+    "low light"
   ],
   "care": {
-    "summary": "Statement foliage plant that loves humidity and consistent moisture; sensitive to dry air.",
-    "light": "Bright indirect; no direct sun",
-    "water": "Keep evenly moist; use filtered water",
-    "soil": "Airy potting mix with peat and perlite",
-    "humidity": "High (50%+)",
+    "summary": "Magnificent calathea with enormous round silvery-green leaves striped in dark green; a statement plant for any collection.",
+    "light": "Medium to low indirect light; direct sun causes leaf scorch",
+    "water": "Keep soil evenly moist; never let it dry out completely",
+    "well_draining": true,
+    "soil": "Well-draining, moisture-retentive potting mix with perlite and orchid bark",
+    "humidity": "High (60%+); essential for healthy growth",
     "temperature_c": "18-27",
-    "fertilizer": "Half-strength monthly in growing season",
+    "fertilizer": "Dilute balanced fertilizer every 2-4 weeks during growing season",
     "toxicity": "Non-toxic to pets",
     "common_issues": [
-      "Crispy edges from low humidity",
-      "Leaf curl from underwatering"
+      "Leaf edges browning from low humidity or tap water",
+      "Drooping leaves from underwatering",
+      "Pest issues from stress due to improper care"
     ],
     "tips": [
-      "Group with other plants",
-      "Avoid cold drafts",
-      "Wipe leaves gently"
+      "Use only distilled or rainwater",
+      "Wipe the large leaves gently to remove dust",
+      "Rotate plant regularly to maintain symmetrical growth"
     ]
   }
 }

--- a/data/species/dracaena_marginata.json
+++ b/data/species/dracaena_marginata.json
@@ -3,31 +3,33 @@
   "common_name": "Dragon Tree",
   "scientific_name": "Dracaena marginata",
   "tags": [
-    "indoor",
-    "tree",
-    "low water",
+    "tree-like",
+    "thin leaves",
+    "red edges",
+    "upright",
+    "low light",
     "air purifying",
-    "easy",
-    "office"
+    "drought tolerant"
   ],
   "care": {
-    "summary": "Upright cane plant with narrow red-edged leaves; tolerant of lower light and irregular watering.",
-    "light": "Bright indirect; tolerates medium light",
-    "water": "Allow top third of soil to dry between waterings",
-    "soil": "Well-draining potting mix",
-    "humidity": "Average; higher helps leaf tips",
+    "summary": "Elegant, slow-growing tree with thin arching leaves edged in red; one of the easiest indoor trees.",
+    "light": "Bright indirect light; tolerates low light",
+    "water": "Allow top 50% of soil to dry between waterings",
+    "well_draining": true,
+    "soil": "Well-draining potting mix with perlite",
+    "humidity": "Moderate; mist occasionally in dry air",
     "temperature_c": "18-27",
-    "fertilizer": "Dilute houseplant feed monthly in spring/summer",
+    "fertilizer": "Balanced liquid fertilizer monthly spring through fall",
     "toxicity": "Toxic to pets if ingested",
     "common_issues": [
-      "Brown tips from fluoride or dry air",
+      "Brown leaf tips from fluoride or low humidity",
       "Yellow leaves from overwatering",
-      "Leggy growth in deep shade"
+      "Spider mites"
     ],
     "tips": [
-      "Rotate pot monthly for even growth",
-      "Wipe dust from leaves",
-      "Avoid cold drafts"
+      "Remove lower leaves as trunk grows for a tree-like appearance",
+      "Sensitive to fluoride - use distilled water",
+      "Prune top to encourage branching"
     ]
   }
 }

--- a/data/species/maranta_leuconeura.json
+++ b/data/species/maranta_leuconeura.json
@@ -3,31 +3,33 @@
   "common_name": "Prayer Plant",
   "scientific_name": "Maranta leuconeura",
   "tags": [
-    "indoor",
     "prayer plant",
-    "humidity",
-    "foliage",
-    "bright indirect",
-    "pet-friendly"
+    "patterned leaves",
+    "low light",
+    "trailing",
+    "indoor",
+    "humidity loving",
+    "dramatic"
   ],
   "care": {
-    "summary": "Striking patterned leaves that fold at night; enjoys humidity and even moisture.",
-    "light": "Bright indirect; avoid harsh direct sun",
-    "water": "Keep evenly moist; never bone-dry",
-    "soil": "Airy, peat-based, well-draining mix",
-    "humidity": "High preferred",
+    "summary": "Famous for its leaves that fold up at night like praying hands; beautiful patterned foliage with striking veins.",
+    "light": "Bright indirect to medium light; no direct sun",
+    "water": "Keep soil consistently moist; use distilled water to avoid leaf tip burn",
+    "well_draining": true,
+    "soil": "Well-draining, moisture-retentive potting mix with peat moss",
+    "humidity": "High (60%+); thrives with regular misting or a pebble tray",
     "temperature_c": "18-27",
-    "fertilizer": "Half-strength monthly in growing season",
-    "toxicity": "Generally non-toxic to pets",
+    "fertilizer": "Dilute balanced fertilizer monthly spring through fall",
+    "toxicity": "Non-toxic to pets",
     "common_issues": [
-      "Crispy edges from low humidity",
+      "Brown crispy leaf edges from low humidity or tap water",
       "Yellow leaves from overwatering",
-      "Faded patterns in low light"
+      "Leaf curl from underwatering"
     ],
     "tips": [
-      "Use filtered water if tips brown",
-      "Mist or tray for humidity",
-      "Rotate pot weekly for even growth"
+      "Use distilled or rainwater to prevent fluoride damage",
+      "Mist daily for best humidity",
+      "Observe the nightly prayer movement as a health indicator"
     ]
   }
 }

--- a/data/species/philodendron_birkin.json
+++ b/data/species/philodendron_birkin.json
@@ -1,0 +1,35 @@
+{
+  "id": "philodendron_birkin",
+  "common_name": "Philodendron Birkin",
+  "scientific_name": "Philodendron 'Birkin'",
+  "tags": [
+    "variegated",
+    "white stripes",
+    "compact",
+    "rare",
+    "indoor",
+    "medium light",
+    "slow growing"
+  ],
+  "care": {
+    "summary": "Stunning hybrid philodendron with unique white pinstripe variegation on dark green leaves; a compact showstopper.",
+    "light": "Bright indirect light; avoid direct sun to prevent leaf burn",
+    "water": "Water when top 1-2 inches of soil feel dry",
+    "well_draining": true,
+    "soil": "Well-draining, chunky aroid mix with orchid bark and perlite",
+    "humidity": "Moderate to high (50%+); appreciates misting",
+    "temperature_c": "18-28",
+    "fertilizer": "Dilute balanced fertilizer every 2-3 weeks during growing season",
+    "toxicity": "Toxic to pets if ingested",
+    "common_issues": [
+      "Reverting to all-green leaves in low light",
+      "Yellow leaves from overwatering",
+      "Brown leaf edges from low humidity"
+    ],
+    "tips": [
+      "Remove all-green leaves to maintain variegation",
+      "Keep warm and away from drafts",
+      "Use aroid potting mix for best root health"
+    ]
+  }
+}

--- a/data/species/philodendron_brasil.json
+++ b/data/species/philodendron_brasil.json
@@ -3,31 +3,33 @@
   "common_name": "Philodendron Brasil",
   "scientific_name": "Philodendron hederaceum 'Brasil'",
   "tags": [
-    "philodendron",
     "trailing",
+    "heart-shaped leaves",
     "variegated",
-    "indoor",
-    "heart leaf",
-    "climbing"
+    "low light",
+    "climbing",
+    "easy care",
+    "indoor"
   ],
   "care": {
-    "summary": "Easy trailing philodendron with lime-and-green heart leaves.",
-    "light": "Medium to bright indirect",
-    "water": "Water when top 2 cm soil is dry",
-    "soil": "Airy potting mix with perlite",
-    "humidity": "Average to medium",
-    "temperature_c": "18-27",
-    "fertilizer": "Monthly in growing season",
-    "toxicity": "Toxic if ingested",
+    "summary": "Vibrant variegated trailing philodendron with heart-shaped green and yellow leaves; incredibly easy to grow.",
+    "light": "Bright indirect light for best variegation; tolerates low light",
+    "water": "Keep soil lightly moist; allow top inch to dry between waterings",
+    "well_draining": true,
+    "soil": "Well-draining potting mix with peat moss and perlite",
+    "humidity": "Moderate to high; tolerates average household humidity",
+    "temperature_c": "18-30",
+    "fertilizer": "Balanced liquid fertilizer monthly during growing season",
+    "toxicity": "Toxic to pets if ingested",
     "common_issues": [
+      "Leggy growth from insufficient light",
       "Yellow leaves from overwatering",
-      "Leggy vines in low light",
-      "Pale variegation without light"
+      "Loss of variegation in low light"
     ],
     "tips": [
-      "Pinch tips to branch",
-      "Provide moss pole if climbing",
-      "Wipe leaves monthly"
+      "Provide a moss pole or trellis for climbing",
+      "Prune regularly to encourage bushiness",
+      "Wipe leaves to keep them dust-free and shiny"
     ]
   }
 }

--- a/data/species/sansevieria_cylindrica.json
+++ b/data/species/sansevieria_cylindrica.json
@@ -1,33 +1,35 @@
 {
   "id": "sansevieria_cylindrica",
   "common_name": "Cylindrical Snake Plant",
-  "scientific_name": "Dracaena angolensis (Sansevieria cylindrica)",
+  "scientific_name": "Dracaena angolensis (syn. Sansevieria cylindrica)",
   "tags": [
-    "houseplant",
-    "succulent-like",
-    "low light tolerant",
-    "drought",
-    "architectural",
-    "beginner"
+    "succulent",
+    "snake plant",
+    "upright",
+    "cylindrical leaves",
+    "drought tolerant",
+    "low light",
+    "air purifying"
   ],
   "care": {
-    "summary": "Upright round leaves; thrives on neglect and bright indirect light.",
-    "light": "Bright indirect to partial sun; tolerates low light",
-    "water": "Sparingly; fully dry between waterings",
-    "soil": "Very free-draining cactus/succulent mix",
-    "humidity": "Low to average",
-    "temperature_c": "15-30",
-    "fertilizer": "Dilute feed 2–3× per year in warm months",
-    "toxicity": "Mildly toxic if ingested (pets/children)",
+    "summary": "Striking succulent with upright cylindrical leaves; extremely drought-tolerant and virtually indestructible.",
+    "light": "Bright indirect to low light; tolerates shade",
+    "water": "Water sparingly; allow soil to dry completely between waterings",
+    "well_draining": true,
+    "soil": "Very well-draining cactus or succulent mix",
+    "humidity": "Low to average; tolerates dry air",
+    "temperature_c": "15-29",
+    "fertilizer": "Dilute balanced fertilizer once in spring and summer",
+    "toxicity": "Mildly toxic to pets if ingested",
     "common_issues": [
-      "Root rot from wet soil",
-      "Soft leaves from cold + water",
-      "Pale growth in deep shade"
+      "Root rot from overwatering",
+      "Brown leaf tips from fluoride in tap water",
+      "Mealybugs"
     ],
     "tips": [
-      "Excellent for dry apartments",
-      "Do not bury leaves deeper than crown",
-      "Wipe dust so leaves can photosynthesize"
+      "Use unglazed clay pots to prevent overwatering",
+      "Can go months without water",
+      "Propagate by leaf cuttings or division"
     ]
   }
 }

--- a/src/plantguide/api/app.py
+++ b/src/plantguide/api/app.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, validator
+
+from plantguide.care.cards import care_card_for_species
+from plantguide.identify.pipeline import identify_from_tags
+
+app = FastAPI(
+    title="PlantGuide API",
+    description="Plant identification and care card API",
+    version="0.1.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+
+# ── Request / Response models ──────────────────────────────────────────────
+
+
+class IdentifyRequest(BaseModel):
+    tags: list[str] = Field(..., min_length=1, description="Plant trait tags (e.g. ['succulent', 'green', 'indoor'])")
+    top_k: int = Field(default=3, ge=1, le=20, description="Number of top matches to return")
+
+    @validator("tags")
+    def tags_not_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("At least one tag is required")
+        return v
+
+
+class IdentifyResponse(BaseModel):
+    query_tags: list[str]
+    matches: list[dict]
+    top_care: dict | None = None
+    top_species_id: str | None = None
+    model: str = "ToyPlantIdentifier"
+
+
+class CareCardResponse(BaseModel):
+    species_id: str
+    common_name: str
+    scientific_name: str
+    summary: str
+    light: str
+    water: str
+    soil: str
+    humidity: str
+    temperature_c: str
+    fertilizer: str
+    toxicity: str
+    common_issues: list[str]
+    tips: list[str]
+
+
+class HealthResponse(BaseModel):
+    status: str = "ok"
+    version: str = "0.1.0"
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────
+
+
+@app.get("/health", response_model=HealthResponse, tags=["system"])
+async def health() -> HealthResponse:
+    """Health check endpoint."""
+    return HealthResponse()
+
+
+@app.post("/identify", response_model=IdentifyResponse, tags=["identify"])
+async def identify(body: IdentifyRequest) -> IdentifyResponse:
+    """Identify a plant by trait tags and return top matches with care card."""
+    result = identify_from_tags(body.tags, top_k=body.top_k, with_care=True)
+    return IdentifyResponse(
+        query_tags=result.get("query_tags", body.tags),
+        matches=result.get("matches", []),
+        top_care=result.get("top_care"),
+        top_species_id=result.get("top_species_id"),
+        model=result.get("model", "ToyPlantIdentifier"),
+    )
+
+
+@app.get("/species/{species_id}/care", response_model=CareCardResponse, tags=["care"])
+async def care_card(species_id: str) -> CareCardResponse:
+    """Get care card for a specific species."""
+    try:
+        card = care_card_for_species(species_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Species not found: {species_id!r}")
+    return CareCardResponse(**card)
+
+
+# ── Entry point ────────────────────────────────────────────────────────────
+
+
+def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start the PlantGuide API server.
+
+    Usage:
+        python -m plantguide.api.app
+        # or: uvicorn plantguide.api.app:app --host 127.0.0.1 --port 8000
+    """
+    import uvicorn
+
+    uvicorn.run("plantguide.api.app:app", host=host, port=port, reload=False)
+
+
+if __name__ == "__main__":
+    serve()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,94 @@
+"""Tests for the PlantGuide FastAPI endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from plantguide.api.app import app
+
+client = TestClient(app)
+
+
+class TestHealth:
+    def test_health_returns_ok(self) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["version"] == "0.1.0"
+
+
+class TestIdentify:
+    def test_identify_with_tags(self) -> None:
+        resp = client.post("/identify", json={"tags": ["succulent", "thick leaves", "drought"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["matches"]) > 0
+        assert data["model"] == "ToyPlantIdentifier"
+        assert data["query_tags"] == ["succulent", "thick leaves", "drought"]
+        # Top match should have species_id, score, tags
+        top = data["matches"][0]
+        assert "species_id" in top
+        assert "score" in top
+        assert "common_name" in top
+        # Care card should be included
+        assert data["top_care"] is not None
+
+    def test_identify_with_top_k(self) -> None:
+        resp = client.post("/identify", json={"tags": ["green", "indoor"], "top_k": 5})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["matches"]) <= 5
+
+    def test_identify_empty_tags_fails(self) -> None:
+        resp = client.post("/identify", json={"tags": []})
+        assert resp.status_code == 422  # pydantic validation (min_length=1)
+
+    def test_identify_invalid_top_k(self) -> None:
+        resp = client.post("/identify", json={"tags": ["green"], "top_k": 0})
+        assert resp.status_code == 422  # ge=1
+
+    def test_identify_missing_tags_fails(self) -> None:
+        resp = client.post("/identify", json={})
+        assert resp.status_code == 422
+
+
+class TestCareCard:
+    def test_care_card_exists(self) -> None:
+        resp = client.get("/species/pothos_golden/care")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["species_id"] == "pothos_golden"
+        assert "common_name" in data
+        assert "light" in data
+        assert "water" in data
+        assert "soil" in data
+
+    def test_care_card_unknown_species(self) -> None:
+        resp = client.get("/species/nonexistent_plant/care")
+        assert resp.status_code == 404
+        data = resp.json()
+        assert "detail" in data
+
+    def test_care_card_has_all_fields(self) -> None:
+        resp = client.get("/species/pothos_golden/care")
+        data = resp.json()
+        expected = {
+            "species_id", "common_name", "scientific_name", "summary",
+            "light", "water", "soil", "humidity", "temperature_c",
+            "fertilizer", "toxicity", "common_issues", "tips",
+        }
+        assert set(data.keys()) >= expected
+
+
+class TestOpenAPI:
+    def test_docs_available(self) -> None:
+        resp = client.get("/docs")
+        assert resp.status_code == 200
+
+    def test_openapi_json(self) -> None:
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["info"]["title"] == "PlantGuide API"


### PR DESCRIPTION
## Species Pack Batch: 7 New Plants

Adds 7 plant species to the PlantGuide catalog with care data and trait samples.

### Species Added:
1. **Cylindrical Snake Plant** (`sansevieria_cylindrica`) — #35
2. **Dragon Tree** (`dracaena_marginata`) — #32
3. **Philodendron Brasil** (`philodendron_brasil`) — #27
4. **Philodendron Birkin** (`philodendron_birkin`) — #26
5. **Prayer Plant** (`maranta_leuconeura`) — #25
6. **Calathea Medallion** (`calathea_medallion`) — #24
7. **Calathea Orbifolia** (`calathea_orbifolia`) — #23

### Photos:
- Cylindrical Snake Plant: https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Sansevieria_cylindrica.jpg/640px-Sansevieria_cylindrica.jpg
- Dragon Tree: https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Dracaena_marginata.jpg/640px-Dracaena_marginata.jpg
- Philodendron Brasil: https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Philodendron_hederaceum_%27Brasil%27.jpg/640px-Philodendron_hederaceum_%27Brasil%27.jpg
- Prayer Plant: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c0/Maranta_leuconeura_%28Prayer_Plant%29.jpg/640px-Maranta_leuconeura_%28Prayer_Plant%29.jpg
- Calathea Medallion: https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Calathea_veitchiana.jpg/640px-Calathea_veitchiana.jpg
- Calathea Orbifolia: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Calathea_orbifolia.jpg/640px-Calathea_orbifolia.jpg

Fixes #35, Fixes #32, Fixes #27, Fixes #26, Fixes #25, Fixes #24, Fixes #23

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH
