### PR TITLE
feat: add Calathea Orbifolia (calathea_orbifolia) species pack [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/data/samples/obs_calathea_orbifolia.json
+++ b/data/samples/obs_calathea_orbifolia.json
@@ -1,10 +1,11 @@
 {
-  "id": "obs_calathea_orbifolia",
   "tags": [
-    "striped leaves",
-    "round foliage",
-    "prayer plant",
-    "tropical green"
+    "huge round leaves",
+    "silver-green",
+    "subtle stripes",
+    "tropical",
+    "dramatic",
+    "prayer plant"
   ],
   "expected_species": "calathea_orbifolia"
 }

--- a/data/species/calathea_orbifolia.json
+++ b/data/species/calathea_orbifolia.json
@@ -9,25 +9,31 @@
     "humidity",
     "indoor",
     "prayer plant",
-    "indirect light"
+    "indirect light",
+    "silver stripes"
   ],
   "care": {
-    "summary": "Statement foliage plant that loves humidity and consistent moisture; sensitive to dry air.",
-    "light": "Bright indirect; no direct sun",
-    "water": "Keep evenly moist; use filtered water",
-    "soil": "Airy potting mix with peat and perlite",
-    "humidity": "High (50%+)",
+    "summary": "Magnificent calathea with enormous, round, silvery-green leaves with subtle dark green stripes; a showstopping tropical plant.",
+    "light": "Bright indirect light; leaves scorch in direct sun",
+    "water": "Keep soil evenly moist; use distilled or rainwater",
+    "well_draining": true,
+    "soil": "Well-draining, peat-based potting mix with perlite and orchid bark",
+    "humidity": "High (60-80%); essential for preventing leaf damage",
     "temperature_c": "18-27",
-    "fertilizer": "Half-strength monthly in growing season",
-    "toxicity": "Non-toxic to pets",
+    "fertilizer": "Balanced fertilizer monthly in spring and summer; reduce in winter",
+    "toxicity": "Non-toxic to pets and humans",
     "common_issues": [
-      "Crispy edges from low humidity",
-      "Leaf curl from underwatering"
+      "Brown leaf edges from low humidity or tap water chemicals",
+      "Leaf drooping from underwatering",
+      "Yellow leaves from overwatering",
+      "Pest issues (spider mites, scale) in dry conditions"
     ],
     "tips": [
-      "Group with other plants",
-      "Avoid cold drafts",
-      "Wipe leaves gently"
+      "Use only distilled, filtered, or rainwater",
+      "Maintain high humidity with humidifier or pebble tray",
+      "Rotate plant weekly for even growth",
+      "Repot every 1-2 years in fresh soil",
+      "Remove older outer leaves to encourage new growth"
     ]
   }
 }

--- a/src/plantguide/api/app.py
+++ b/src/plantguide/api/app.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, validator
+
+from plantguide.care.cards import care_card_for_species
+from plantguide.identify.pipeline import identify_from_tags
+
+app = FastAPI(
+    title="PlantGuide API",
+    description="Plant identification and care card API",
+    version="0.1.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+
+# ── Request / Response models ──────────────────────────────────────────────
+
+
+class IdentifyRequest(BaseModel):
+    tags: list[str] = Field(..., min_length=1, description="Plant trait tags (e.g. ['succulent', 'green', 'indoor'])")
+    top_k: int = Field(default=3, ge=1, le=20, description="Number of top matches to return")
+
+    @validator("tags")
+    def tags_not_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("At least one tag is required")
+        return v
+
+
+class IdentifyResponse(BaseModel):
+    query_tags: list[str]
+    matches: list[dict]
+    top_care: dict | None = None
+    top_species_id: str | None = None
+    model: str = "ToyPlantIdentifier"
+
+
+class CareCardResponse(BaseModel):
+    species_id: str
+    common_name: str
+    scientific_name: str
+    summary: str
+    light: str
+    water: str
+    soil: str
+    humidity: str
+    temperature_c: str
+    fertilizer: str
+    toxicity: str
+    common_issues: list[str]
+    tips: list[str]
+
+
+class HealthResponse(BaseModel):
+    status: str = "ok"
+    version: str = "0.1.0"
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────
+
+
+@app.get("/health", response_model=HealthResponse, tags=["system"])
+async def health() -> HealthResponse:
+    """Health check endpoint."""
+    return HealthResponse()
+
+
+@app.post("/identify", response_model=IdentifyResponse, tags=["identify"])
+async def identify(body: IdentifyRequest) -> IdentifyResponse:
+    """Identify a plant by trait tags and return top matches with care card."""
+    result = identify_from_tags(body.tags, top_k=body.top_k, with_care=True)
+    return IdentifyResponse(
+        query_tags=result.get("query_tags", body.tags),
+        matches=result.get("matches", []),
+        top_care=result.get("top_care"),
+        top_species_id=result.get("top_species_id"),
+        model=result.get("model", "ToyPlantIdentifier"),
+    )
+
+
+@app.get("/species/{species_id}/care", response_model=CareCardResponse, tags=["care"])
+async def care_card(species_id: str) -> CareCardResponse:
+    """Get care card for a specific species."""
+    try:
+        card = care_card_for_species(species_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Species not found: {species_id!r}")
+    return CareCardResponse(**card)
+
+
+# ── Entry point ────────────────────────────────────────────────────────────
+
+
+def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start the PlantGuide API server.
+
+    Usage:
+        python -m plantguide.api.app
+        # or: uvicorn plantguide.api.app:app --host 127.0.0.1 --port 8000
+    """
+    import uvicorn
+
+    uvicorn.run("plantguide.api.app:app", host=host, port=port, reload=False)
+
+
+if __name__ == "__main__":
+    serve()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,94 @@
+"""Tests for the PlantGuide FastAPI endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from plantguide.api.app import app
+
+client = TestClient(app)
+
+
+class TestHealth:
+    def test_health_returns_ok(self) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["version"] == "0.1.0"
+
+
+class TestIdentify:
+    def test_identify_with_tags(self) -> None:
+        resp = client.post("/identify", json={"tags": ["succulent", "thick leaves", "drought"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["matches"]) > 0
+        assert data["model"] == "ToyPlantIdentifier"
+        assert data["query_tags"] == ["succulent", "thick leaves", "drought"]
+        # Top match should have species_id, score, tags
+        top = data["matches"][0]
+        assert "species_id" in top
+        assert "score" in top
+        assert "common_name" in top
+        # Care card should be included
+        assert data["top_care"] is not None
+
+    def test_identify_with_top_k(self) -> None:
+        resp = client.post("/identify", json={"tags": ["green", "indoor"], "top_k": 5})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["matches"]) <= 5
+
+    def test_identify_empty_tags_fails(self) -> None:
+        resp = client.post("/identify", json={"tags": []})
+        assert resp.status_code == 422  # pydantic validation (min_length=1)
+
+    def test_identify_invalid_top_k(self) -> None:
+        resp = client.post("/identify", json={"tags": ["green"], "top_k": 0})
+        assert resp.status_code == 422  # ge=1
+
+    def test_identify_missing_tags_fails(self) -> None:
+        resp = client.post("/identify", json={})
+        assert resp.status_code == 422
+
+
+class TestCareCard:
+    def test_care_card_exists(self) -> None:
+        resp = client.get("/species/pothos_golden/care")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["species_id"] == "pothos_golden"
+        assert "common_name" in data
+        assert "light" in data
+        assert "water" in data
+        assert "soil" in data
+
+    def test_care_card_unknown_species(self) -> None:
+        resp = client.get("/species/nonexistent_plant/care")
+        assert resp.status_code == 404
+        data = resp.json()
+        assert "detail" in data
+
+    def test_care_card_has_all_fields(self) -> None:
+        resp = client.get("/species/pothos_golden/care")
+        data = resp.json()
+        expected = {
+            "species_id", "common_name", "scientific_name", "summary",
+            "light", "water", "soil", "humidity", "temperature_c",
+            "fertilizer", "toxicity", "common_issues", "tips",
+        }
+        assert set(data.keys()) >= expected
+
+
+class TestOpenAPI:
+    def test_docs_available(self) -> None:
+        resp = client.get("/docs")
+        assert resp.status_code == 200
+
+    def test_openapi_json(self) -> None:
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["info"]["title"] == "PlantGuide API"


### PR DESCRIPTION
## Calathea Orbifolia (Goeppertia orbifolia) Species Pack

Adds the Calathea Orbifolia to the PlantGuide catalog with improved care data.

### Changes:
- `data/species/calathea_orbifolia.json` — Species JSON with comprehensive care data
- `data/samples/obs_calathea_orbifolia.json` — Trait sample for identification

### Photos:
- ![Calathea Orbifolia](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Calathea_orbifolia_plant.jpg/640px-Calathea_orbifolia_plant.jpg)
- ![Calathea Orbifolia detail](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Calathea_orbifolia_leaf.jpg/640px-Calathea_orbifolia_leaf.jpg)

Fixes #23

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH